### PR TITLE
fix: fixa versão da imagem node para 20.18.2

### DIFF
--- a/node.dockerfile
+++ b/node.dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20.18.2-alpine
 
 COPY dist /var/www
 


### PR DESCRIPTION
A ultima subida realizada para produção aumentou o consumo de memória no servidor, verificamos algumas reclamações relacionadas a versão 20 do node:alpine em issues no github.
![image](https://github.com/user-attachments/assets/60f207d0-42dc-4ec0-8794-f933ba95a6a9)
