### PR TITLE
feat: adicionar campo isFree no token de declaredInterest

### DIFF
--- a/src/modules/prepCourse/studentCourse/student-course.repository.ts
+++ b/src/modules/prepCourse/studentCourse/student-course.repository.ts
@@ -168,6 +168,7 @@ export class StudentCourseRepository extends NodeRepository<StudentCourse> {
         'users.lastName',
         'users.socialName',
         'users.email',
+        'entity.isFree',
       ])
       .innerJoinAndSelect('entity.partnerPrepCourse', 'partnerPrepCourse')
       .innerJoinAndSelect('partnerPrepCourse.geo', 'geo')

--- a/src/modules/prepCourse/studentCourse/student-course.repository.ts
+++ b/src/modules/prepCourse/studentCourse/student-course.repository.ts
@@ -168,7 +168,6 @@ export class StudentCourseRepository extends NodeRepository<StudentCourse> {
         'users.lastName',
         'users.socialName',
         'users.email',
-        'entity.isFree',
       ])
       .innerJoinAndSelect('entity.partnerPrepCourse', 'partnerPrepCourse')
       .innerJoinAndSelect('partnerPrepCourse.geo', 'geo')

--- a/src/modules/prepCourse/studentCourse/student-course.service.ts
+++ b/src/modules/prepCourse/studentCourse/student-course.service.ts
@@ -620,7 +620,7 @@ export class StudentCourseService extends BaseService<StudentCourse> {
         const results = await Promise.allSettled(
           chunk.map(async (stu) => {
             try {
-              const payload = { user: { id: stu.id } };
+              const payload = { user: { id: stu.id, isFree: stu.isFree } };
               const limitTimeInSeconds = Math.floor(
                 stu.limitEnrolledAt.getTime() / 1000,
               );


### PR DESCRIPTION
---

### **Descrição do Pull Request**

Este Pull Request adiciona a lógica necessária para adicionar campo `isFree` durante incriptação do token no fluxo student-course `sendEmailDeclaredInterest`. 

---

### **Motivação**

- Garantir que a mensagem apresentada na declaração de interesse seja personalizada de acordo com a propriedade `isFree` do token durante exibição no front-end.
- Melhorar a experiência do usuário ao fornecer informações mais claras e relevantes no processo seletivo.

---

### **Alterações Realizadas**

1. Adicionada lógica para codificar a propriedade `isFree` no token retornado ao front.
2. Retornar campo isFree no repository
---