### PR TITLE
feat: add roleId to JWT and get method to CacheService

### DIFF
--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -408,7 +408,11 @@ export class UserService extends BaseService<User> {
     }
 
     // Gera o access token (15 minutos)
-    const accessToken = await this.jwtService.signAsync({ user, roles });
+    const accessToken = await this.jwtService.signAsync({
+      user,
+      roles,
+      roleId: domain.role.id,
+    });
 
     // Gera o refresh token (7 dias)
     const refreshToken = await this.refreshTokenService.generateRefreshToken(
@@ -507,6 +511,7 @@ export class UserService extends BaseService<User> {
     const accessToken = await this.jwtService.signAsync({
       user: userDto,
       roles,
+      roleId: user.role.id,
     });
 
     this.logger.log(`Access token renovado para usuário: ${user.id}`);

--- a/src/shared/modules/cache/cache.service.ts
+++ b/src/shared/modules/cache/cache.service.ts
@@ -18,6 +18,10 @@ export class CacheService {
     return result;
   }
 
+  async get<T>(key: string): Promise<T | undefined> {
+    return await this.cacheManager.get<T>(key);
+  }
+
   async del(key: string) {
     await this.cacheManager.del(key);
   }


### PR DESCRIPTION
Include roleId in access token payload (login and refresh) so frontend can identify the user's current role. Add a pure get() method to CacheService for read-only lookups without side effects.