### PR TITLE
fix(inscription): invalidar cache ao atualizar status via cron

### DIFF
--- a/src/modules/prepCourse/InscriptionCourse/inscription-course.service.ts
+++ b/src/modules/prepCourse/InscriptionCourse/inscription-course.service.ts
@@ -454,6 +454,7 @@ export class InscriptionCourseService extends BaseService<InscriptionCourse> {
   async updateInfosInscription() {
     try {
       await this.repository.updateAllInscriptionsStatus();
+      await this.cache.del('inscription-course:open');
     } catch (error) {
       this.discordWebhook.sendMessage(
         `Erro ao atualizar status das inscrições: ${error}`,


### PR DESCRIPTION
O cron updateInfosInscription já atualizava o status dos processos seletivos mas não limpava o cache, causando dados stale no widget.