### PR TITLE
fix(docker): corrige caminho main.js no container

### DIFF
--- a/node.dockerfile
+++ b/node.dockerfile
@@ -11,7 +11,7 @@ FROM node:20-alpine
 WORKDIR /var/www
 
 COPY --from=deps /app/node_modules ./node_modules
-COPY dist ./
+COPY dist/src/. ./
 COPY src/shared/services/assets/* shared/services/assets/
 COPY src/shared/services/email/templates/* shared/services/email/templates/
 COPY package.json .


### PR DESCRIPTION
## Summary
- `tsconfig.json` usa `include: ["."]`, então `nest build` emite `dist/src/main.js` (não `dist/main.js`).
- `node.dockerfile` fazia `COPY dist ./`, colocando entry em `/var/www/src/main.js`, enquanto `CMD ["pm2-runtime", "main.js"]` procurava `/var/www/main.js`.
- Resultado em homol: PM2 `Script not found: /var/www/main.js` e container saía com exit 137.
- Mesmo Dockerfile é usado por `ci-prod.yml`, então qualquer `git tag v*` reproduziria bug em produção.

Fix: `COPY dist/src/. ./` — flatten do conteúdo compilado direto em `/var/www`.

## Test plan
- [ ] Merge em `develop` dispara `ci-homol.yml` (job PUSH + DEPLOY_HOMOL)
- [ ] Confirmar `docker logs -f vcnafacul` em homol mostra NestJS subindo sem `Script not found`
- [ ] Health check da API em homol responde
- [ ] Validar rotas que dependem de assets em `shared/services/assets/` e templates de email
- [ ] Só taguear `v*` depois de homol estável

🤖 Generated with [Claude Code](https://claude.com/claude-code)