### PR TITLE
feat: news rich text + destaque + home supporter description

### DIFF
--- a/src/db/migrations/1777165085256-NovidadesDestaqueDescription.ts
+++ b/src/db/migrations/1777165085256-NovidadesDestaqueDescription.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class NovidadesDestaqueDescription1777165085256
+  implements MigrationInterface
+{
+  name = 'NovidadesDestaqueDescription1777165085256';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`news\` DROP COLUMN \`session\``);
+    await queryRunner.query(
+      `ALTER TABLE \`news\` ADD \`description\` varchar(280) NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`news\` ADD \`destaque\` tinyint NOT NULL DEFAULT 0`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`news\` DROP COLUMN \`destaque\``);
+    await queryRunner.query(
+      `ALTER TABLE \`news\` DROP COLUMN \`description\``,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`news\` ADD \`session\` varchar(255) NOT NULL DEFAULT ''`,
+    );
+  }
+}

--- a/src/db/migrations/1777169513218-NewsRichText.ts
+++ b/src/db/migrations/1777169513218-NewsRichText.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class NewsRichText1777169513218 implements MigrationInterface {
+    name = 'NewsRichText1777169513218'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`news\` ADD \`body\` text NULL`);
+        await queryRunner.query(`ALTER TABLE \`news\` ADD \`content_type\` enum ('file', 'text') NOT NULL DEFAULT 'file'`);
+        await queryRunner.query(`ALTER TABLE \`news\` CHANGE \`fileName\` \`fileName\` varchar(255) NULL`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`news\` CHANGE \`fileName\` \`fileName\` varchar(255) NOT NULL`);
+        await queryRunner.query(`ALTER TABLE \`news\` DROP COLUMN \`content_type\``);
+        await queryRunner.query(`ALTER TABLE \`news\` DROP COLUMN \`body\``);
+    }
+
+}

--- a/src/db/migrations/1777217821772-HomeSupporterDescription.ts
+++ b/src/db/migrations/1777217821772-HomeSupporterDescription.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class HomeSupporterDescription1777217821772
+  implements MigrationInterface
+{
+  name = 'HomeSupporterDescription1777217821772';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`home_supporter\` ADD \`description\` varchar(280) NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`home_supporter\` DROP COLUMN \`description\``,
+    );
+  }
+}

--- a/src/modules/home-content/dtos/create-home-supporter.dto.ts
+++ b/src/modules/home-content/dtos/create-home-supporter.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsUrl, MaxLength } from 'class-validator';
+import { IsOptional, IsString, IsUrl, MaxLength } from 'class-validator';
 
 export class CreateHomeSupporterDto {
   @IsString()
@@ -11,4 +11,10 @@ export class CreateHomeSupporterDto {
   @MaxLength(512)
   @ApiProperty()
   link: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(280)
+  @ApiProperty({ required: false })
+  description?: string;
 }

--- a/src/modules/home-content/dtos/update-home-supporter.dto.ts
+++ b/src/modules/home-content/dtos/update-home-supporter.dto.ts
@@ -13,4 +13,10 @@ export class UpdateHomeSupporterDto {
   @MaxLength(512)
   @ApiProperty({ required: false })
   link?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(280)
+  @ApiProperty({ required: false })
+  description?: string;
 }

--- a/src/modules/home-content/dtos/update-home-supporter.dto.ts
+++ b/src/modules/home-content/dtos/update-home-supporter.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, IsUrl, MaxLength } from 'class-validator';
+import {
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+  ValidateIf,
+} from 'class-validator';
 
 export class UpdateHomeSupporterDto {
   @IsOptional()
@@ -15,8 +21,9 @@ export class UpdateHomeSupporterDto {
   link?: string;
 
   @IsOptional()
+  @ValidateIf((_, value) => value !== null)
   @IsString()
   @MaxLength(280)
-  @ApiProperty({ required: false })
-  description?: string;
+  @ApiProperty({ required: false, nullable: true })
+  description?: string | null;
 }

--- a/src/modules/home-content/entities/home-supporter.entity.ts
+++ b/src/modules/home-content/entities/home-supporter.entity.ts
@@ -20,6 +20,9 @@ export class HomeSupporter {
   @Column({ type: 'varchar', length: 512 })
   link: string;
 
+  @Column({ type: 'varchar', length: 280, nullable: true })
+  description: string | null;
+
   @Column({ type: 'int', default: 0 })
   order: number;
 

--- a/src/modules/home-content/home-content.service.spec.ts
+++ b/src/modules/home-content/home-content.service.spec.ts
@@ -51,7 +51,9 @@ describe('HomeContentService', () => {
     blobService = {
       uploadFile: jest.fn().mockResolvedValue('new-key'),
       deleteFile: jest.fn().mockResolvedValue(undefined),
-      getFile: jest.fn().mockResolvedValue({ buffer: 'b64', contentType: 'image/png' }),
+      getFile: jest
+        .fn()
+        .mockResolvedValue({ buffer: 'b64', contentType: 'image/png' }),
     };
 
     service = new HomeContentService(
@@ -193,7 +195,9 @@ describe('HomeContentService', () => {
       aboutRepo.findSingleton.mockResolvedValue(existing);
       blobService.deleteFile.mockRejectedValueOnce(new Error('boom'));
 
-      await expect(service.uploadAboutThumbnail(fakeFile)).resolves.toBeDefined();
+      await expect(
+        service.uploadAboutThumbnail(fakeFile),
+      ).resolves.toBeDefined();
     });
   });
 
@@ -246,9 +250,9 @@ describe('HomeContentService', () => {
       it('throws NOT_FOUND when feature does not exist', async () => {
         featureRepo.findById.mockResolvedValue(null);
 
-        await expect(
-          service.updateFeature(1, { title: 'x' }),
-        ).rejects.toThrow(HttpException);
+        await expect(service.updateFeature(1, { title: 'x' })).rejects.toThrow(
+          HttpException,
+        );
       });
 
       it('patches only provided fields', async () => {
@@ -320,9 +324,9 @@ describe('HomeContentService', () => {
       it('throws NOT_FOUND when feature missing', async () => {
         featureRepo.findById.mockResolvedValue(null);
 
-        await expect(
-          service.uploadFeatureImage(1, fakeFile),
-        ).rejects.toThrow(HttpException);
+        await expect(service.uploadFeatureImage(1, fakeFile)).rejects.toThrow(
+          HttpException,
+        );
       });
 
       it('uploads, replaces previous image and invalidates caches', async () => {
@@ -379,9 +383,9 @@ describe('HomeContentService', () => {
       it('throws NOT_FOUND when supporter does not exist', async () => {
         supporterRepo.findById.mockResolvedValue(null);
 
-        await expect(
-          service.updateSupporter(1, { name: 'x' }),
-        ).rejects.toThrow(HttpException);
+        await expect(service.updateSupporter(1, { name: 'x' })).rejects.toThrow(
+          HttpException,
+        );
       });
 
       it('patches fields and invalidates cache', async () => {
@@ -395,6 +399,48 @@ describe('HomeContentService', () => {
         expect(saved.name).toBe('Novo');
         expect(saved.link).toBe('https://novo.com');
         expect(cache.del).toHaveBeenCalledWith(CACHE_KEYS.supporters);
+      });
+    });
+
+    describe('createSupporter — description', () => {
+      it('persiste description quando fornecida', async () => {
+        supporterRepo.maxOrder.mockResolvedValue(0);
+        const dto = {
+          name: 'ACME',
+          link: 'https://acme.com',
+          description: 'Empresa apoiadora',
+        };
+        await service.createSupporter(dto as any);
+        expect(supporterRepo.save).toHaveBeenCalledWith(
+          expect.objectContaining({ description: 'Empresa apoiadora' }),
+        );
+      });
+
+      it('aceita description ausente (null)', async () => {
+        supporterRepo.maxOrder.mockResolvedValue(0);
+        const dto = { name: 'ACME', link: 'https://acme.com' };
+        await service.createSupporter(dto as any);
+        expect(supporterRepo.save).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'ACME', link: 'https://acme.com' }),
+        );
+      });
+    });
+
+    describe('updateSupporter — description', () => {
+      it('atualiza description quando fornecida', async () => {
+        const existing = {
+          id: 1,
+          name: 'ACME',
+          link: 'https://acme.com',
+          description: null,
+        } as HomeSupporter;
+        supporterRepo.findById.mockResolvedValue(existing);
+        await service.updateSupporter(1, {
+          description: 'Nova descrição',
+        } as any);
+        expect(supporterRepo.save).toHaveBeenCalledWith(
+          expect.objectContaining({ description: 'Nova descrição' }),
+        );
       });
     });
 
@@ -452,9 +498,9 @@ describe('HomeContentService', () => {
       it('throws NOT_FOUND when supporter missing', async () => {
         supporterRepo.findById.mockResolvedValue(null);
 
-        await expect(
-          service.uploadSupporterLogo(1, fakeFile),
-        ).rejects.toThrow(HttpException);
+        await expect(service.uploadSupporterLogo(1, fakeFile)).rejects.toThrow(
+          HttpException,
+        );
       });
 
       it('uploads new logo, removes previous and invalidates caches', async () => {

--- a/src/modules/home-content/home-content.service.spec.ts
+++ b/src/modules/home-content/home-content.service.spec.ts
@@ -421,7 +421,11 @@ describe('HomeContentService', () => {
         const dto = { name: 'ACME', link: 'https://acme.com' };
         await service.createSupporter(dto as any);
         expect(supporterRepo.save).toHaveBeenCalledWith(
-          expect.objectContaining({ name: 'ACME', link: 'https://acme.com' }),
+          expect.objectContaining({
+            name: 'ACME',
+            link: 'https://acme.com',
+            description: null,
+          }),
         );
       });
     });

--- a/src/modules/home-content/home-content.service.ts
+++ b/src/modules/home-content/home-content.service.ts
@@ -223,6 +223,7 @@ export class HomeContentService {
     const entity = new HomeSupporter();
     entity.name = dto.name;
     entity.link = dto.link;
+    entity.description = dto.description ?? null;
     entity.order = (await this.supporterRepo.maxOrder()) + 1;
     const saved = await this.supporterRepo.save(entity);
     await this.cache.del(CACHE_KEYS.supporters);
@@ -239,6 +240,9 @@ export class HomeContentService {
     }
     if (dto.name !== undefined) entity.name = dto.name;
     if (dto.link !== undefined) entity.link = dto.link;
+    if (dto.description !== undefined) {
+      entity.description = dto.description;
+    }
     const saved = await this.supporterRepo.save(entity);
     await this.cache.del(CACHE_KEYS.supporters);
     return saved;

--- a/src/modules/news/dtos/create-news.dto.input.ts
+++ b/src/modules/news/dtos/create-news.dto.input.ts
@@ -1,14 +1,36 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsDateString,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+import { Transform } from 'class-transformer';
 
 export class CreateNewsDtoInput {
   @IsString()
   @ApiProperty()
-  session: string;
-
-  @IsString()
-  @ApiProperty()
   title: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(280)
+  @ApiProperty({
+    description: 'Descrição exibida no card destaque (máx 280 chars)',
+    required: false,
+  })
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @ApiProperty({
+    description: 'Se true, define esta novidade como destaque (zera as outras)',
+    required: false,
+    default: false,
+  })
+  destaque?: boolean;
 
   @IsOptional()
   @IsDateString()

--- a/src/modules/news/dtos/create-news.dto.input.ts
+++ b/src/modules/news/dtos/create-news.dto.input.ts
@@ -1,12 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import {
   IsBoolean,
   IsDateString,
+  IsIn,
   IsOptional,
   IsString,
   MaxLength,
 } from 'class-validator';
-import { Transform } from 'class-transformer';
 
 export class CreateNewsDtoInput {
   @IsString()
@@ -31,6 +32,25 @@ export class CreateNewsDtoInput {
     default: false,
   })
   destaque?: boolean;
+
+  @IsOptional()
+  @IsIn(['file', 'text'])
+  @ApiProperty({
+    description: 'Tipo de conteúdo: file (upload) ou text (markdown). Default: file.',
+    required: false,
+    enum: ['file', 'text'],
+    default: 'file',
+  })
+  contentType?: 'file' | 'text';
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(50000)
+  @ApiProperty({
+    description: 'Markdown da novidade (obrigatório quando contentType=text, máx 50000 chars)',
+    required: false,
+  })
+  body?: string;
 
   @IsOptional()
   @IsDateString()

--- a/src/modules/news/dtos/update-news.dto.input.ts
+++ b/src/modules/news/dtos/update-news.dto.input.ts
@@ -1,16 +1,28 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsDateString,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 
 export class UpdateNewsDtoInput {
   @IsOptional()
   @IsString()
   @ApiProperty({ required: false })
-  session?: string;
+  title?: string;
 
   @IsOptional()
   @IsString()
+  @MaxLength(280)
+  @ApiProperty({ required: false, description: 'Descrição (máx 280 chars)' })
+  description?: string;
+
+  @IsOptional()
+  @IsBoolean()
   @ApiProperty({ required: false })
-  title?: string;
+  destaque?: boolean;
 
   @IsOptional()
   @IsDateString()

--- a/src/modules/news/dtos/update-news.dto.input.ts
+++ b/src/modules/news/dtos/update-news.dto.input.ts
@@ -25,6 +25,15 @@ export class UpdateNewsDtoInput {
   destaque?: boolean;
 
   @IsOptional()
+  @IsString()
+  @MaxLength(50000)
+  @ApiProperty({
+    required: false,
+    description: 'Markdown da novidade (apenas para contentType=text)',
+  })
+  body?: string;
+
+  @IsOptional()
   @IsDateString()
   @ApiProperty({
     description: 'Data de expiração (YYYY-MM-DD), deve ser hoje ou futura',

--- a/src/modules/news/news.controller.ts
+++ b/src/modules/news/news.controller.ts
@@ -75,7 +75,7 @@ export class NewsController {
   @ApiBearerAuth()
   @ApiResponse({
     status: 200,
-    description: 'atualizar novidade (session, title, expire_at)',
+    description: 'atualizar novidade (title, description, destaque, expire_at)',
   })
   @UseGuards(PermissionsGuard)
   @SetMetadata(PermissionsGuard.name, Permissions.uploadNews)

--- a/src/modules/news/news.controller.ts
+++ b/src/modules/news/news.controller.ts
@@ -71,11 +71,30 @@ export class NewsController {
     return await this.newService.create(body, file, (req.user as User).id);
   }
 
+  @Post('assets')
+  @ApiBearerAuth()
+  @ApiResponse({
+    status: 201,
+    description: 'Upload de imagem para uso em corpo de novidade tipo text',
+    schema: {
+      type: 'object',
+      properties: {
+        assetId: { type: 'string' },
+      },
+    },
+  })
+  @UseGuards(PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.uploadNews)
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadAsset(@UploadedFile() file: Express.Multer.File) {
+    return await this.newService.uploadAsset(file);
+  }
+
   @Patch(':id')
   @ApiBearerAuth()
   @ApiResponse({
     status: 200,
-    description: 'atualizar novidade (title, description, destaque, expire_at)',
+    description: 'atualizar novidade (title, description, destaque, body, expire_at)',
   })
   @UseGuards(PermissionsGuard)
   @SetMetadata(PermissionsGuard.name, Permissions.uploadNews)

--- a/src/modules/news/news.entity.ts
+++ b/src/modules/news/news.entity.ts
@@ -5,10 +5,10 @@ import { User } from '../user/user.entity';
 @Entity('news')
 export class News extends BaseEntity {
   @Column()
-  session: string;
-
-  @Column()
   title: string;
+
+  @Column({ length: 280, nullable: true })
+  description: string | null;
 
   @Column()
   fileName: string;
@@ -18,6 +18,9 @@ export class News extends BaseEntity {
 
   @Column({ default: true })
   actived: boolean;
+
+  @Column({ default: false })
+  destaque: boolean;
 
   @Column({ name: 'expire_at', type: 'date', nullable: true })
   expireAt: Date | null;

--- a/src/modules/news/news.entity.ts
+++ b/src/modules/news/news.entity.ts
@@ -2,6 +2,8 @@ import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { BaseEntity } from '../../shared/modules/base/entity.base';
 import { User } from '../user/user.entity';
 
+export type NewsContentType = 'file' | 'text';
+
 @Entity('news')
 export class News extends BaseEntity {
   @Column()
@@ -10,8 +12,19 @@ export class News extends BaseEntity {
   @Column({ length: 280, nullable: true })
   description: string | null;
 
-  @Column()
-  fileName: string;
+  @Column({ nullable: true })
+  fileName: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  body: string | null;
+
+  @Column({
+    name: 'content_type',
+    type: 'enum',
+    enum: ['file', 'text'],
+    default: 'file',
+  })
+  contentType: NewsContentType;
 
   @Column({ name: 'updated_by' })
   updatedBy: string;

--- a/src/modules/news/news.repository.ts
+++ b/src/modules/news/news.repository.ts
@@ -51,4 +51,21 @@ export class NewsRepository extends BaseRepository<News> {
       .where('entity.deletedAt IS NULL')
       .getCount();
   }
+
+  async unsetAllDestaqueExcept(
+    excludeId: string | null,
+    manager: EntityManager,
+  ): Promise<void> {
+    const qb = manager
+      .createQueryBuilder()
+      .update(News)
+      .set({ destaque: false })
+      .where('destaque = :flag', { flag: true });
+
+    if (excludeId) {
+      qb.andWhere('id != :id', { id: excludeId });
+    }
+
+    await qb.execute();
+  }
 }

--- a/src/modules/news/news.service.ts
+++ b/src/modules/news/news.service.ts
@@ -1,5 +1,7 @@
 import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
+import { InjectEntityManager } from '@nestjs/typeorm';
+import { EntityManager } from 'typeorm';
 import { BaseService } from 'src/shared/modules/base/base.service';
 import { GetAllOutput } from 'src/shared/modules/base/interfaces/get-all.output';
 import { CacheService } from 'src/shared/modules/cache/cache.service';
@@ -60,6 +62,7 @@ export class NewsService extends BaseService<News> {
     private envService: EnvService,
     private readonly cache: CacheService,
     @Inject('BlobService') private readonly blobService: BlobService,
+    @InjectEntityManager() private readonly entityManager: EntityManager,
   ) {
     super(repository);
   }
@@ -79,31 +82,55 @@ export class NewsService extends BaseService<News> {
     if (!fileKey) {
       throw new HttpException('error to upload file', HttpStatus.BAD_REQUEST);
     }
-    const news = new News();
-    news.session = request.session;
-    news.title = request.title;
-    news.fileName = fileKey;
-    news.updatedBy = userId;
-    news.expireAt = expireAt ?? null;
 
-    return await this.repository.create(news);
+    return await this.entityManager.transaction(async (manager) => {
+      if (request.destaque === true) {
+        await this.repository.unsetAllDestaqueExcept(null, manager);
+      }
+
+      const news = manager.create(News, {
+        title: request.title,
+        description: request.description ?? null,
+        fileName: fileKey,
+        updatedBy: userId,
+        destaque: request.destaque === true,
+        expireAt: expireAt ?? null,
+      });
+
+      return await manager.save(News, news);
+    });
   }
 
   async update(id: string, request: UpdateNewsDtoInput, userId: string) {
-    const news = await this.repository.findOneBy({ id });
-    if (!news) {
-      throw new HttpException('Novidade não encontrada', HttpStatus.NOT_FOUND);
-    }
-    if (request.expire_at !== undefined) {
-      const expireAt = parseExpireAt(request.expire_at);
-      validateExpireAtNotInPast(expireAt);
-      news.expireAt = expireAt;
-    }
-    if (request.session !== undefined) news.session = request.session;
-    if (request.title !== undefined) news.title = request.title;
-    news.updatedBy = userId;
-    await this.repository.update(news);
-    return news;
+    return await this.entityManager.transaction(async (manager) => {
+      const news = await manager.findOne(News, { where: { id } });
+      if (!news) {
+        throw new HttpException(
+          'Novidade não encontrada',
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (request.expire_at !== undefined) {
+        const expireAt = parseExpireAt(request.expire_at);
+        validateExpireAtNotInPast(expireAt);
+        news.expireAt = expireAt;
+      }
+      if (request.title !== undefined) news.title = request.title;
+      if (request.description !== undefined) {
+        news.description = request.description || null;
+      }
+      if (request.destaque === true) {
+        await this.repository.unsetAllDestaqueExcept(id, manager);
+        news.destaque = true;
+      } else if (request.destaque === false) {
+        news.destaque = false;
+      }
+      news.updatedBy = userId;
+
+      await manager.save(News, news);
+      return news;
+    });
   }
 
   async getFile(

--- a/src/modules/news/news.service.ts
+++ b/src/modules/news/news.service.ts
@@ -13,6 +13,7 @@ import { GetAllNewsDtoInput } from './dtos/get-all-news';
 import { UpdateNewsDtoInput } from './dtos/update-news.dto.input';
 import { News } from './news.entity';
 import { NewsRepository } from './news.repository';
+import { parseAssetIds } from './utils/parse-asset-ids';
 
 const CACHE_MAX_AGE_DAYS = 7;
 const CACHE_MAX_AGE_SECONDS = CACHE_MAX_AGE_DAYS * 24 * 60 * 60;
@@ -55,6 +56,42 @@ function validateExpireAtNotInPast(expireAt: Date | null): void {
   }
 }
 
+function validateXorContent(opts: {
+  contentType: 'file' | 'text';
+  hasFile: boolean;
+  body: string | null | undefined;
+}): void {
+  const { contentType, hasFile, body } = opts;
+  const hasBody = !!body && body.trim().length > 0;
+  if (contentType === 'text') {
+    if (!hasBody) {
+      throw new HttpException(
+        'body é obrigatório quando contentType=text',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    if (hasFile) {
+      throw new HttpException(
+        'envie file OU body, não ambos',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  } else {
+    if (!hasFile) {
+      throw new HttpException(
+        'file é obrigatório quando contentType=file',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    if (hasBody) {
+      throw new HttpException(
+        'envie file OU body, não ambos',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+}
+
 @Injectable()
 export class NewsService extends BaseService<News> {
   constructor(
@@ -69,18 +106,28 @@ export class NewsService extends BaseService<News> {
 
   async create(
     request: CreateNewsDtoInput,
-    file: Express.Multer.File,
+    file: Express.Multer.File | undefined,
     userId: string,
   ) {
     const expireAt = parseExpireAt(request.expire_at);
     validateExpireAtNotInPast(expireAt);
 
-    const fileKey = await this.blobService.uploadFile(
-      file,
-      this.envService.get('BUCKET_NEWS'),
-    );
-    if (!fileKey) {
-      throw new HttpException('error to upload file', HttpStatus.BAD_REQUEST);
+    const contentType: 'file' | 'text' = request.contentType ?? 'file';
+    validateXorContent({
+      contentType,
+      hasFile: !!file,
+      body: request.body,
+    });
+
+    let fileKey: string | null = null;
+    if (contentType === 'file') {
+      fileKey = await this.blobService.uploadFile(
+        file as Express.Multer.File,
+        this.envService.get('BUCKET_NEWS'),
+      );
+      if (!fileKey) {
+        throw new HttpException('error to upload file', HttpStatus.BAD_REQUEST);
+      }
     }
 
     return await this.entityManager.transaction(async (manager) => {
@@ -92,6 +139,8 @@ export class NewsService extends BaseService<News> {
         title: request.title,
         description: request.description ?? null,
         fileName: fileKey,
+        body: contentType === 'text' ? (request.body as string) : null,
+        contentType,
         updatedBy: userId,
         destaque: request.destaque === true,
         expireAt: expireAt ?? null,
@@ -101,13 +150,31 @@ export class NewsService extends BaseService<News> {
     });
   }
 
-  async update(id: string, request: UpdateNewsDtoInput, userId: string) {
+  async update(
+    id: string,
+    request: UpdateNewsDtoInput & { contentType?: unknown },
+    userId: string,
+  ) {
+    if ('contentType' in request && request.contentType !== undefined) {
+      throw new HttpException(
+        'contentType não pode ser alterado',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     return await this.entityManager.transaction(async (manager) => {
       const news = await manager.findOne(News, { where: { id } });
       if (!news) {
         throw new HttpException(
           'Novidade não encontrada',
           HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (request.body !== undefined && news.contentType !== 'text') {
+        throw new HttpException(
+          'body só pode ser atualizado em novidades tipo text',
+          HttpStatus.BAD_REQUEST,
         );
       }
 
@@ -120,6 +187,24 @@ export class NewsService extends BaseService<News> {
       if (request.description !== undefined) {
         news.description = request.description || null;
       }
+
+      if (request.body !== undefined) {
+        const oldIds = parseAssetIds(news.body);
+        const newIds = parseAssetIds(request.body);
+        const removed = oldIds.filter((aid) => !newIds.includes(aid));
+        for (const assetId of removed) {
+          try {
+            await this.blobService.deleteFile(
+              assetId,
+              this.envService.get('BUCKET_NEWS'),
+            );
+          } catch {
+            // best-effort
+          }
+        }
+        news.body = request.body;
+      }
+
       if (request.destaque === true) {
         await this.repository.unsetAllDestaqueExcept(id, manager);
         news.destaque = true;
@@ -131,6 +216,20 @@ export class NewsService extends BaseService<News> {
       await manager.save(News, news);
       return news;
     });
+  }
+
+  async uploadAsset(file: Express.Multer.File): Promise<{ assetId: string }> {
+    const fileKey = await this.blobService.uploadFile(
+      file,
+      this.envService.get('BUCKET_NEWS'),
+    );
+    if (!fileKey) {
+      throw new HttpException(
+        'Erro ao fazer upload do asset',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    return { assetId: fileKey };
   }
 
   async getFile(
@@ -148,7 +247,24 @@ export class NewsService extends BaseService<News> {
 
   override async delete(id: string): Promise<void> {
     const news = await this.repository.findOneBy({ id });
-    if (news?.fileName) {
+    if (!news) {
+      await this.repository.delete(id);
+      return;
+    }
+
+    if (news.contentType === 'text' && news.body) {
+      const assetIds = parseAssetIds(news.body);
+      for (const assetId of assetIds) {
+        try {
+          await this.blobService.deleteFile(
+            assetId,
+            this.envService.get('BUCKET_NEWS'),
+          );
+        } catch {
+          // best-effort
+        }
+      }
+    } else if (news.fileName) {
       try {
         await this.blobService.deleteFile(
           news.fileName,
@@ -158,6 +274,7 @@ export class NewsService extends BaseService<News> {
         // ignora falha ao remover do S3; registro é removido mesmo assim
       }
     }
+
     await this.repository.delete(id);
   }
 

--- a/src/modules/news/utils/parse-asset-ids.ts
+++ b/src/modules/news/utils/parse-asset-ids.ts
@@ -1,0 +1,10 @@
+const ASSET_PATTERN = /asset:\/\/([a-zA-Z0-9._-]+)/gi;
+
+export function parseAssetIds(markdown: string | null | undefined): string[] {
+  if (!markdown) return [];
+  const ids = new Set<string>();
+  for (const match of markdown.matchAll(ASSET_PATTERN)) {
+    ids.add(match[1]);
+  }
+  return Array.from(ids);
+}

--- a/test/news.e2e-spec.ts
+++ b/test/news.e2e-spec.ts
@@ -1,0 +1,169 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { AppModule } from 'src/app.module';
+import { News } from 'src/modules/news/news.entity';
+import { User } from 'src/modules/user/user.entity';
+import { Gender } from 'src/modules/user/enum/gender';
+import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
+import { PermissionsGuard } from 'src/shared/guards/permission.guard';
+import { DiscordWebhook } from 'src/shared/services/webhooks/discord';
+import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import { createNestAppTest } from './utils/createNestAppTest';
+
+jest.mock('src/shared/services/blob/blob-service.ts');
+jest.mock('src/shared/services/webhooks/discord.ts');
+
+describe('News destaque mutex (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let fakeUserId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(DiscordWebhook)
+      .useValue({ sendMessage: jest.fn() })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (ctx: any) => {
+          const req = ctx.switchToHttp().getRequest();
+          req.user = { id: fakeUserId };
+          return true;
+        },
+      })
+      .overrideGuard(PermissionsGuard)
+      .useValue({
+        canActivate: (ctx: any) => {
+          const req = ctx.switchToHttp().getRequest();
+          req.user = { id: fakeUserId };
+          return true;
+        },
+      })
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = createNestAppTest(moduleFixture);
+    dataSource = moduleFixture.get<DataSource>(DataSource);
+
+    const blobService = moduleFixture.get<any>('BlobService');
+    let counter = 0;
+    jest
+      .spyOn(blobService, 'uploadFile')
+      .mockImplementation(async () => `news-fake-key-${++counter}`);
+    jest
+      .spyOn(blobService, 'getFile')
+      .mockImplementation(async () => ({
+        buffer: '',
+        contentType: 'application/octet-stream',
+      }));
+    jest.spyOn(blobService, 'deleteFile').mockImplementation(async () => {});
+
+    await app.init();
+
+    const userRepo = dataSource.getRepository(User);
+    const user = userRepo.create({
+      email: `news-test-${Date.now()}@example.com`,
+      password: 'irrelevant',
+      firstName: 'News',
+      lastName: 'Tester',
+      phone: '0000',
+      gender: Gender.Male,
+      birthday: new Date('1990-01-01'),
+      state: 'SP',
+      city: 'SP',
+      lgpd: true,
+    });
+    const saved = await userRepo.save(user);
+    fakeUserId = saved.id;
+  });
+
+  afterAll(async () => {
+    if (app) {
+      await dataSource
+        .createQueryBuilder()
+        .delete()
+        .from(News)
+        .execute()
+        .catch(() => undefined);
+      await app.close();
+    }
+  });
+
+  async function listNews(): Promise<News[]> {
+    return dataSource.getRepository(News).find();
+  }
+
+  async function createNews(opts: {
+    title: string;
+    destaque?: boolean;
+    description?: string;
+  }) {
+    const req = request(app.getHttpServer())
+      .post('/news')
+      .field('title', opts.title);
+    if (opts.destaque !== undefined) {
+      req.field('destaque', String(opts.destaque));
+    }
+    if (opts.description !== undefined) {
+      req.field('description', opts.description);
+    }
+    return req.attach('file', Buffer.from('fake-docx-content'), 'fake.docx');
+  }
+
+  it('cria com destaque=true', async () => {
+    const res = await createNews({ title: 'A', destaque: true });
+    expect(res.status).toBe(201);
+    expect(res.body.destaque).toBe(true);
+  });
+
+  it('marcar segunda novidade como destaque desmarca a primeira', async () => {
+    const second = await createNews({ title: 'B', destaque: true });
+    expect(second.status).toBe(201);
+    expect(second.body.destaque).toBe(true);
+
+    const all = await listNews();
+    const flagged = all.filter((n) => n.destaque);
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].title).toBe('B');
+  });
+
+  it('PATCH destaque=true em outra registra mutex no banco', async () => {
+    const third = await createNews({ title: 'C', destaque: false });
+    const id = third.body.id;
+
+    const patch = await request(app.getHttpServer())
+      .patch(`/news/${id}`)
+      .send({ destaque: true });
+    expect(patch.status).toBe(200);
+
+    const all = await listNews();
+    const flagged = all.filter((n) => n.destaque);
+    expect(flagged).toHaveLength(1);
+    expect(flagged[0].id).toBe(id);
+  });
+
+  it('rejeita description com mais de 280 chars no PATCH', async () => {
+    const news = await createNews({ title: 'D' });
+    const id = news.body.id;
+
+    const res = await request(app.getHttpServer())
+      .patch(`/news/${id}`)
+      .send({ description: 'x'.repeat(281) });
+    expect(res.status).toBe(400);
+  });
+
+  it('aceita description com até 280 chars', async () => {
+    const news = await createNews({ title: 'E' });
+    const id = news.body.id;
+
+    const res = await request(app.getHttpServer())
+      .patch(`/news/${id}`)
+      .send({ description: 'x'.repeat(280) });
+    expect(res.status).toBe(200);
+    expect(res.body.description).toHaveLength(280);
+  });
+});

--- a/test/news.e2e-spec.ts
+++ b/test/news.e2e-spec.ts
@@ -166,4 +166,135 @@ describe('News destaque mutex (e2e)', () => {
     expect(res.status).toBe(200);
     expect(res.body.description).toHaveLength(280);
   });
+
+  describe('rich text content (text type)', () => {
+    it('cria news tipo text com body', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/news')
+        .send({
+          title: 'TextNews',
+          contentType: 'text',
+          body: '# Hello\n\nworld',
+        });
+      expect(res.status).toBe(201);
+      expect(res.body.contentType).toBe('text');
+      expect(res.body.body).toContain('Hello');
+      expect(res.body.fileName).toBeNull();
+    });
+
+    it('rejeita text sem body', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/news')
+        .send({
+          title: 'NoBody',
+          contentType: 'text',
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejeita body com mais de 50000 chars', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/news')
+        .send({
+          title: 'Big',
+          contentType: 'text',
+          body: 'x'.repeat(50001),
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('PATCH ignora contentType e mantém o tipo original', async () => {
+      const created = await request(app.getHttpServer())
+        .post('/news')
+        .send({
+          title: 'Locked',
+          contentType: 'text',
+          body: 'content',
+        });
+      const id = created.body.id;
+      const patch = await request(app.getHttpServer())
+        .patch(`/news/${id}`)
+        .send({ contentType: 'file', title: 'Updated' });
+      expect(patch.status).toBe(200);
+      expect(patch.body.contentType).toBe('text');
+      expect(patch.body.title).toBe('Updated');
+    });
+
+    it('rejeita PATCH com body em news tipo file', async () => {
+      const created = await createNews({ title: 'FileType' });
+      const id = created.body.id;
+      const patch = await request(app.getHttpServer())
+        .patch(`/news/${id}`)
+        .send({ body: 'tentativa' });
+      expect(patch.status).toBe(400);
+    });
+
+    it('PATCH atualiza body em news tipo text', async () => {
+      const created = await request(app.getHttpServer())
+        .post('/news')
+        .send({
+          title: 'EditableText',
+          contentType: 'text',
+          body: 'v1',
+        });
+      const id = created.body.id;
+      const patch = await request(app.getHttpServer())
+        .patch(`/news/${id}`)
+        .send({ body: 'v2' });
+      expect(patch.status).toBe(200);
+      expect(patch.body.body).toBe('v2');
+    });
+
+    it('POST /news/assets retorna assetId', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/news/assets')
+        .attach('file', Buffer.from('PNG-bytes'), 'pic.png');
+      expect(res.status).toBe(201);
+      expect(typeof res.body.assetId).toBe('string');
+      expect(res.body.assetId.length).toBeGreaterThan(0);
+    });
+
+    it('DELETE em news text remove assets do bucket', async () => {
+      const blobService = app.get<any>('BlobService');
+      const deleteSpy = jest.spyOn(blobService, 'deleteFile');
+      deleteSpy.mockClear();
+
+      const created = await request(app.getHttpServer())
+        .post('/news')
+        .send({
+          title: 'WithAssets',
+          contentType: 'text',
+          body: 'before ![](asset://abc) middle ![](asset://def) end',
+        });
+      const id = created.body.id;
+
+      await request(app.getHttpServer()).delete(`/news/${id}`);
+
+      const deletedKeys = deleteSpy.mock.calls.map((c: any) => c[0]);
+      expect(deletedKeys).toEqual(expect.arrayContaining(['abc', 'def']));
+    });
+
+    it('PATCH body remove apenas assets que sumiram', async () => {
+      const blobService = app.get<any>('BlobService');
+      const deleteSpy = jest.spyOn(blobService, 'deleteFile');
+      deleteSpy.mockClear();
+
+      const created = await request(app.getHttpServer())
+        .post('/news')
+        .send({
+          title: 'Diffed',
+          contentType: 'text',
+          body: 'a ![](asset://aaa) b ![](asset://bbb)',
+        });
+      const id = created.body.id;
+
+      await request(app.getHttpServer())
+        .patch(`/news/${id}`)
+        .send({ body: 'a ![](asset://aaa) c' });
+
+      const deletedKeys = deleteSpy.mock.calls.map((c: any) => c[0]);
+      expect(deletedKeys).toContain('bbb');
+      expect(deletedKeys).not.toContain('aaa');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Múltiplas features no api-vcnafacul:

### Novidades — Destaque + Descrição
- Drop coluna `session`; add `destaque BOOLEAN` (mutex atômico via transaction) + `description VARCHAR(280)`
- DTOs aceitam `destaque` + `description`
- Repository method para limpar flag destaque
- Controller swagger atualizado

### Novidades — Rich Text (TipTap)
- `content_type ENUM('file','text')` discriminator; `body TEXT NULL` para text mode; `fileName` agora nullable
- DTO XOR: `contentType='file'` exige `fileName`; `contentType='text'` exige `body`, `contentType` travado em update
- POST `/news/assets` para upload de imagens inline (deferred upload via `PendingImageStore`)
- Cleanup de assets órfãs no DELETE e PATCH
- Helper para parse de asset IDs do markdown

### Home Supporter — Descrição
- Migration aditiva: `home_supporter.description VARCHAR(280) NULL`
- DTOs Create/Update aceitam `description?: string \| null`
- UpdateDto com `@ValidateIf((_, v) => v !== null)` para aceitar null explícito (limpar campo)
- Service: create normaliza para `null`, update usa `!== undefined` (PATCH semantics)
- Cache invalidação existente preservada

## Test plan

- [ ] Migration `npm run migration:run` em DB local + `migration:revert`
- [ ] DTO validations: 280/281 chars description, null payload aceito
- [ ] news.e2e-spec passing (cobertura nova p/ destaque mutex + xor)
- [ ] Smoke test endpoints `/home-content/supporters` + `/news/assets` + `/news` (file vs text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)