### PR TITLE
feat(mail): add fake SMTP support via Mailpit for non-production envi…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: mailpit
+    restart: unless-stopped
+    ports:
+      - "8025:8025"
+    expose:
+      - "1025"
+    environment:
+      MP_MAX_MESSAGES: 500
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+    networks:
+      - network-vcnafacul
+    volumes:
+      - mailpit_data:/data
+
+volumes:
+  mailpit_data:
+
+
+networks:
+  network-vcnafacul:
+    external: true

--- a/src/shared/modules/env/env.ts
+++ b/src/shared/modules/env/env.ts
@@ -43,6 +43,10 @@ export const envSchema = z.object({
   MAIL_PASSWORD: z.string().default('password'),
   TEMPLATE_EMAIL: z.string().default('vcnafacul'),
   TEMPLATE_EMAIL_ASSET: z.string().default('vcnafacul'),
+  SMTP_FAKE: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
 
   //S3
   BLOB_PROVIDER: z.enum(['S3']).default('S3'),

--- a/src/shared/modules/env/env.ts
+++ b/src/shared/modules/env/env.ts
@@ -43,7 +43,7 @@ export const envSchema = z.object({
   MAIL_PASSWORD: z.string().default('password'),
   TEMPLATE_EMAIL: z.string().default('vcnafacul'),
   TEMPLATE_EMAIL_ASSET: z.string().default('vcnafacul'),
-  SMTP_FAKE: z
+  USE_SMTP_FAKE: z
     .enum(['true', 'false'])
     .default('false')
     .transform((v) => v === 'true'),

--- a/src/shared/modules/env/env.ts
+++ b/src/shared/modules/env/env.ts
@@ -47,6 +47,8 @@ export const envSchema = z.object({
     .enum(['true', 'false'])
     .default('false')
     .transform((v) => v === 'true'),
+  SMTP_FAKE_HOST: z.string().default('mailpit'),
+  SMTP_FAKE_PORT: z.coerce.number().default(1025),
 
   //S3
   BLOB_PROVIDER: z.enum(['S3']).default('S3'),

--- a/src/shared/services/email/email.service.ts
+++ b/src/shared/services/email/email.service.ts
@@ -25,7 +25,7 @@ export class EmailService {
 
   constructor(private envService: EnvService) {
   const isProd = this.envService.get('NODE_ENV') === 'production';
-  const useFakeSmtp = !isProd && this.envService.get('SMTP_FAKE') === true;
+  const useFakeSmtp = !isProd && this.envService.get('USE_SMTP_FAKE') === true;
 
   this.transporter = nodemailer.createTransport({
     host: useFakeSmtp

--- a/src/shared/services/email/email.service.ts
+++ b/src/shared/services/email/email.service.ts
@@ -28,8 +28,12 @@ export class EmailService {
   const useFakeSmtp = !isProd && this.envService.get('SMTP_FAKE') === true;
 
   this.transporter = nodemailer.createTransport({
-    host: this.envService.get('SMTP_HOST'),
-    port: Number(this.envService.get('SMTP_PORT')),
+    host: useFakeSmtp
+      ? this.envService.get('SMTP_FAKE_HOST')
+      : this.envService.get('SMTP_HOST'),
+    port: useFakeSmtp
+      ? Number(this.envService.get('SMTP_FAKE_PORT'))
+      : Number(this.envService.get('SMTP_PORT')),
     secure: !useFakeSmtp,
     ...(useFakeSmtp ? {} : {
       auth: {

--- a/src/shared/services/email/email.service.ts
+++ b/src/shared/services/email/email.service.ts
@@ -30,7 +30,7 @@ export class EmailService {
   this.transporter = nodemailer.createTransport({
     host: this.envService.get('SMTP_HOST'),
     port: Number(this.envService.get('SMTP_PORT')),
-    secure: useFakeSmtp,
+    secure: !useFakeSmtp,
     ...(useFakeSmtp ? {} : {
       auth: {
         user: this.envService.get('SMTP_USERNAME'),

--- a/src/shared/services/email/email.service.ts
+++ b/src/shared/services/email/email.service.ts
@@ -25,7 +25,7 @@ export class EmailService {
 
   constructor(private envService: EnvService) {
   const isProd = this.envService.get('NODE_ENV') === 'production';
-  const useFakeSmtp = !isProd && this.envService.get('SMTP_FAKE') === 'true';
+  const useFakeSmtp = !isProd && this.envService.get('SMTP_FAKE') === true;
 
   this.transporter = nodemailer.createTransport({
     host: this.envService.get('SMTP_HOST'),

--- a/src/shared/services/email/email.service.ts
+++ b/src/shared/services/email/email.service.ts
@@ -24,15 +24,25 @@ export class EmailService {
   private readonly logger = new Logger(EmailService.name);
 
   constructor(private envService: EnvService) {
-    this.transporter = nodemailer.createTransport({
-      host: this.envService.get('SMTP_HOST'),
-      port: this.envService.get('SMTP_PORT'),
-      secure: true, // true para 465, false para outras portas
+  const isProd = this.envService.get('NODE_ENV') === 'production';
+  const useFakeSmtp = !isProd && this.envService.get('SMTP_FAKE') === 'true';
+
+  this.transporter = nodemailer.createTransport({
+    host: this.envService.get('SMTP_HOST'),
+    port: Number(this.envService.get('SMTP_PORT')),
+    secure: useFakeSmtp,
+    ...(useFakeSmtp ? {} : {
       auth: {
         user: this.envService.get('SMTP_USERNAME'),
         pass: this.envService.get('SMTP_PASSWORD'),
       },
-    });
+    }),
+  });
+
+    if (useFakeSmtp) {
+      this.logger.warn('SMTP_FAKE ativo: usando fake SMTP sem autenticação');
+    }
+
     const templatePath = path.resolve(this.envService.get('TEMPLATE_EMAIL'));
     const handlebarOptions = {
       viewEngine: {


### PR DESCRIPTION
## 📋 Descrição

Adiciona suporte a servidor SMTP fake (Mailpit) em ambientes não-produção, eliminando o risco de envio acidental de e-mails a usuários reais durante desenvolvimento, homologação ou staging.

---

## 🔗 Issue relacionada

[#465 — [Feature] Fake SMTP — captura de e-mails em ambientes não-produção](https://github.com/vcnafacul/api-vcnafacul/issues/465)
---

## 🛠️ O que foi alterado

- Adicionado serviço `mailpit` ao `docker-compose.yml` com porta SMTP (`1025`) interna e Web UI (`8025`) exposta
- Ajustado o transporte SMTP para desativar `auth` e `secure` quando `SMTP_FAKE=true` — desde que não seja `production`
- `NODE_ENV=production` garante uso do SMTP real independentemente de qualquer outra variável
---

## ✅ Critérios atendidos

- [x] E-mails em `dev`/`homologation`/`staging` são capturados pelo Mailpit sem entrega real
- [x] E-mails em `production` utilizam o SMTP real com autenticação e TLS
- [x] `docker compose up` sobe o Mailpit automaticamente em ambiente não-prod
- [x] Interface de inspeção acessível em `http://localhost:8025`
- [x] Nenhuma lógica hard-coded — decisão feita exclusivamente via variáveis de ambiente

---

## 🧪 Como testar

1. Suba o ambiente local:
```bash
   docker compose up
```
2. Dispare qualquer fluxo que envia e-mail (cadastro, recuperação de senha, etc.)
3. Acesse `http://localhost:8025` e verifique o e-mail capturado
4. Confirme que nenhum e-mail chegou ao destinatário real

---

## ⚠️ Variáveis de ambiente necessárias

```env
NODE_ENV=development

# Ativa o SMTP fake (Mailpit)
USE_SMTP_FAKE=true

# SMTP Real (produção)
SMTP_HOST=smtp....
SMTP_PORT=465
SMTP_USERNAME=apikey
SMTP_PASSWORD=sua_senha

# SMTP Fake (opcional — já tem default para mailpit:1025)
SMTP_FAKE_HOST=mailpit
SMTP_FAKE_PORT=1025
```

> Em produção, `USE_SMTP_FAKE` deve ser `false` ou ausente — o SMTP real é sempre utilizado independentemente.

> Em produção, `SMTP_FAKE` é ignorado e o SMTP real é sempre utilizado.