### PR TITLE
fix(role): add missing supportAgent and partnerPrepSupportAgent to DTO and service

### DIFF
--- a/src/modules/role/dto/create-role.dto.ts
+++ b/src/modules/role/dto/create-role.dto.ts
@@ -90,4 +90,10 @@ export class CreateRoleDtoInput {
 
   @IsBoolean()
   revisarTodasRedacoes: boolean;
+
+  @IsBoolean()
+  supportAgent: boolean;
+
+  @IsBoolean()
+  partnerPrepSupportAgent: boolean;
 }

--- a/src/modules/role/role.service.ts
+++ b/src/modules/role/role.service.ts
@@ -119,6 +119,11 @@ export class RoleService extends BaseService<Role> {
     role.gerenciarFormularioGlobal = roleDto.gerenciarFormularioGlobal;
     role.gerenciarFormulario = roleDto.gerenciarFormulario;
     role.gerenciarTemas = roleDto.gerenciarTemas;
+    role.revisarRedacoes = roleDto.revisarRedacoes;
+    role.revisarTodasRedacoes =
+      roleBase?.revisarTodasRedacoes || roleDto.revisarTodasRedacoes;
+    role.supportAgent = roleBase?.supportAgent || roleDto.supportAgent;
+    role.partnerPrepSupportAgent = roleDto.partnerPrepSupportAgent;
 
     if (partnerPrepCourse) {
       role.partnerPrepCourse = partnerPrepCourse;
@@ -186,6 +191,10 @@ export class RoleService extends BaseService<Role> {
     role.gerenciarFormularioGlobal = roleDto.gerenciarFormularioGlobal;
     role.gerenciarFormulario = roleDto.gerenciarFormulario;
     role.gerenciarTemas = roleDto.gerenciarTemas;
+    role.revisarRedacoes = roleDto.revisarRedacoes;
+    role.revisarTodasRedacoes = roleDto.revisarTodasRedacoes;
+    role.supportAgent = roleDto.supportAgent;
+    role.partnerPrepSupportAgent = roleDto.partnerPrepSupportAgent;
 
     // Atualiza permissões das filhas
     if (role.children?.length > 0) {
@@ -208,6 +217,8 @@ export class RoleService extends BaseService<Role> {
           child.gerenciarFormularioGlobal = role.gerenciarFormularioGlobal;
           child.gerenciarFormulario = role.gerenciarFormulario;
           child.gerenciarTemas = role.gerenciarTemas;
+          child.revisarTodasRedacoes = role.revisarTodasRedacoes;
+          child.supportAgent = role.supportAgent;
           await this.roleRepository.update(child);
         }),
       );

--- a/test/course-period.e2e-spec.ts
+++ b/test/course-period.e2e-spec.ts
@@ -125,6 +125,8 @@ describe('CoursePeriod (e2e)', () => {
       gerenciarTemas: false,
       revisarRedacoes: false,
       revisarTodasRedacoes: false,
+      supportAgent: false,
+      partnerPrepSupportAgent: false,
     };
     role = await roleService.create(roleDto);
 

--- a/test/role.e2e-spec.ts
+++ b/test/role.e2e-spec.ts
@@ -85,6 +85,8 @@ describe('Role e2e', () => {
         gerenciarTemas: false,
         revisarRedacoes: false,
         revisarTodasRedacoes: false,
+        supportAgent: false,
+        partnerPrepSupportAgent: false,
       };
 
       const baseRoleResponse = await request(app.getHttpServer())
@@ -133,6 +135,8 @@ describe('Role e2e', () => {
         gerenciarTemas: false,
         revisarRedacoes: false,
         revisarTodasRedacoes: false,
+        supportAgent: false,
+        partnerPrepSupportAgent: false,
       };
 
       const childRoleResponse = await request(app.getHttpServer())
@@ -265,6 +269,8 @@ describe('Role e2e', () => {
         gerenciarTemas: false,
         revisarRedacoes: false,
         revisarTodasRedacoes: false,
+        supportAgent: false,
+        partnerPrepSupportAgent: false,
       };
 
       const baseRoleResponse = await request(app.getHttpServer())
@@ -305,6 +311,8 @@ describe('Role e2e', () => {
         gerenciarTemas: false,
         revisarRedacoes: false,
         revisarTodasRedacoes: false,
+        supportAgent: false,
+        partnerPrepSupportAgent: false,
       };
 
       const childRoleResponse = await request(app.getHttpServer())


### PR DESCRIPTION
## Summary
- Adiciona `supportAgent` e `partnerPrepSupportAgent` ao `CreateRoleDtoInput` (e por herança ao `UpdateRoleDtoInput`)
- Corrige `create()` e `update()` no `RoleService` para atribuir corretamente as 4 permissões que estavam sendo ignoradas: `revisarRedacoes`, `revisarTodasRedacoes`, `supportAgent` e `partnerPrepSupportAgent`
- Adiciona cascade de `revisarTodasRedacoes` e `supportAgent` (permissões de projeto) para roles filhas no `update()`; `revisarRedacoes` e `partnerPrepSupportAgent` (permissões de cursinho) não cascateiam — comportamento consistente com as demais permissões de cursinho

## Test plan
- [ ] Criar uma nova role com `supportAgent: true` e `partnerPrepSupportAgent: true` — verificar que os valores são persistidos no banco
- [ ] Editar uma role existente alternando `revisarRedacoes` e `revisarTodasRedacoes` — verificar persistência
- [ ] Atualizar uma role base que tenha filhas — confirmar que `revisarTodasRedacoes` e `supportAgent` cascateiam para as filhas, mas `revisarRedacoes` e `partnerPrepSupportAgent` não

🤖 Generated with [Claude Code](https://claude.com/claude-code)