### PR TITLE
feat: cards de estudantes atendidos e ativos no monitoramento

### DIFF
--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -29,6 +29,13 @@ export class DashboardController {
 
   @UseGuards(JwtAuthGuard, PermissionsGuard)
   @SetMetadata(PermissionsGuard.name, Permissions.visualizarEstudantes)
+  @Get('students-enrolled')
+  async getStudentsCurrentlyEnrolled() {
+    return this.dashboardService.getStudentsCurrentlyEnrolled();
+  }
+
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.visualizarEstudantes)
   @Get('students-served')
   async getStudentsServed() {
     return this.dashboardService.getStudentsServed();

--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -26,4 +26,11 @@ export class DashboardController {
   async getQuestoesPendentes(@Req() req: any) {
     return this.dashboardService.getQuestoesPendentes(req.user.id);
   }
+
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.visualizarEstudantes)
+  @Get('students-served')
+  async getStudentsServed() {
+    return this.dashboardService.getStudentsServed();
+  }
 }

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -138,6 +138,18 @@ export class DashboardService {
     await this.cache.del(`dashboard:collab:${userId}`);
   }
 
+  async getStudentsCurrentlyEnrolled(): Promise<{ total: number }> {
+    return this.cache.wrap(
+      'dashboard:students-enrolled',
+      async () => {
+        const total =
+          await this.studentCourseRepo.countStudentsCurrentlyEnrolled();
+        return { total };
+      },
+      60 * 60 * 1000, // 1h
+    );
+  }
+
   async getStudentsServed(): Promise<{ total: number }> {
     return this.cache.wrap(
       'dashboard:students-served',

--- a/src/modules/dashboard/dashboard.service.ts
+++ b/src/modules/dashboard/dashboard.service.ts
@@ -138,6 +138,18 @@ export class DashboardService {
     await this.cache.del(`dashboard:collab:${userId}`);
   }
 
+  async getStudentsServed(): Promise<{ total: number }> {
+    return this.cache.wrap(
+      'dashboard:students-served',
+      async () => {
+        const total =
+          await this.studentCourseRepo.countStudentsEffectivelyServed();
+        return { total };
+      },
+      60 * 60 * 1000, // 1h
+    );
+  }
+
   async getQuestoesPendentes(
     userId: string,
   ): Promise<QuestoesPendentesDashboardDtoOutput> {

--- a/src/modules/prepCourse/studentCourse/student-course.repository.ts
+++ b/src/modules/prepCourse/studentCourse/student-course.repository.ts
@@ -353,6 +353,21 @@ export class StudentCourseRepository extends NodeRepository<StudentCourse> {
       .getMany();
   }
 
+  async countStudentsEffectivelyServed(): Promise<number> {
+    const { count } = await this.repository
+      .createQueryBuilder('entity')
+      .select('COUNT(DISTINCT entity.user_id)', 'count')
+      .where('entity.applicationStatus IN (:...statuses)', {
+        statuses: [
+          StatusApplication.Enrolled,
+          StatusApplication.EnrollmentCancelled,
+          StatusApplication.EnrollmentClosed,
+        ],
+      })
+      .getRawOne<{ count: string }>();
+    return parseInt(count, 10);
+  }
+
   async existsByUserId(userId: string): Promise<boolean> {
     const count = await this.repository
       .createQueryBuilder('entity')

--- a/src/modules/prepCourse/studentCourse/student-course.repository.ts
+++ b/src/modules/prepCourse/studentCourse/student-course.repository.ts
@@ -353,6 +353,17 @@ export class StudentCourseRepository extends NodeRepository<StudentCourse> {
       .getMany();
   }
 
+  async countStudentsCurrentlyEnrolled(): Promise<number> {
+    const { count } = await this.repository
+      .createQueryBuilder('entity')
+      .select('COUNT(DISTINCT entity.user_id)', 'count')
+      .where('entity.applicationStatus = :status', {
+        status: StatusApplication.Enrolled,
+      })
+      .getRawOne<{ count: string }>();
+    return parseInt(count, 10);
+  }
+
   async countStudentsEffectivelyServed(): Promise<number> {
     const { count } = await this.repository
       .createQueryBuilder('entity')


### PR DESCRIPTION
## Summary

- Novo endpoint `GET /dashboard/students-served` — conta estudantes que passaram pelos status `Enrolled`, `EnrollmentCancelled` ou `EnrollmentClosed` (efetivamente atendidos pela plataforma)
- Novo endpoint `GET /dashboard/students-enrolled` — conta estudantes atualmente com status `Enrolled` (ativos no momento)
- Ambos usam Redis cache com TTL de 1h e requerem permissão `visualizarEstudantes`

## Test plan

- [ ] `GET /dashboard/students-served` retorna `{ total: N }` com usuário com permissão `visualizarEstudantes`
- [ ] `GET /dashboard/students-enrolled` retorna `{ total: N }` com usuário com permissão `visualizarEstudantes`
- [ ] Requests sem permissão retornam 403
- [ ] Segundo request usa cache (verificar via Redis ou latência)

🤖 Generated with [Claude Code](https://claude.com/claude-code)