### PR TITLE
feat: endpoints públicos de estudantes para seção Impacto do Projeto

### DIFF
--- a/src/modules/dashboard/dashboard.controller.ts
+++ b/src/modules/dashboard/dashboard.controller.ts
@@ -40,4 +40,14 @@ export class DashboardController {
   async getStudentsServed() {
     return this.dashboardService.getStudentsServed();
   }
+
+  @Get('public/students-served')
+  async getPublicStudentsServed() {
+    return this.dashboardService.getStudentsServed();
+  }
+
+  @Get('public/students-enrolled')
+  async getPublicStudentsEnrolled() {
+    return this.dashboardService.getStudentsCurrentlyEnrolled();
+  }
 }


### PR DESCRIPTION
## Summary

- Adiciona `GET /dashboard/public/students-served` (sem auth) — retorna total de estudantes efetivamente atendidos
- Adiciona `GET /dashboard/public/students-enrolled` (sem auth) — retorna total de estudantes ativos

Ambos reutilizam os mesmos métodos de serviço e cache Redis (TTL 1h) dos endpoints autenticados. Criados para uso na página pública "Quem Somos".

## Test plan

- [ ] `GET /dashboard/public/students-served` retorna `{ total: N }` sem token
- [ ] `GET /dashboard/public/students-enrolled` retorna `{ total: N }` sem token
- [ ] Segundo request vem do cache (mesma chave dos endpoints autenticados)

🤖 Generated with [Claude Code](https://claude.com/claude-code)