### PR TITLE
feat(class-analytics): Fase B — class analytics gateway endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ lerna-debug.log*
 .env.homol
 
 /test/coverage.worktrees/
+.worktrees/

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { AttendanceRecordModule } from './modules/prepCourse/attendance/attendan
 import { PeriodJustificationModule } from './modules/prepCourse/attendance/periodJustification/period-justification.module';
 import { StudentAttendanceModule } from './modules/prepCourse/attendance/studentAttendance/student-attendance.module';
 import { ClassModule } from './modules/prepCourse/class/class.module';
+import { ClassAnalyticsModule } from './modules/prepCourse/class/analytics/class-analytics.module';
 import { CollaboratorModule } from './modules/prepCourse/collaborator/collaborator.module';
 import { CoursePeriodModule } from './modules/prepCourse/coursePeriod/course-period.module';
 import { InscriptionCourseModule } from './modules/prepCourse/InscriptionCourse/inscription-course.module';
@@ -106,6 +107,7 @@ const throttlerProvider: Provider = isTestEnv
     BlobModule,
     SimuladoModule,
     ClassModule,
+    ClassAnalyticsModule,
     AttendanceRecordModule,
     StudentAttendanceModule,
     AbsenceJustificationModule,

--- a/src/modules/prepCourse/class/analytics/class-analytics.controller.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  Req,
+  SetMetadata,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { Permissions } from 'src/modules/role/role.entity';
+import { User } from 'src/modules/user/user.entity';
+import { PermissionsGuard } from 'src/shared/guards/permission.guard';
+import { ClassAnalyticsService } from './class-analytics.service';
+import { ListMonthsDtoOutput } from './dtos/list-months.dto.output';
+import { MonthAnalyticsDtoOutput } from './dtos/month-analytics.dto.output';
+import { RefreshDtoOutput } from './dtos/refresh.dto.output';
+
+@ApiTags('Class Analytics')
+@Controller('class/:id/analytics')
+export class ClassAnalyticsController {
+  constructor(private readonly service: ClassAnalyticsService) {}
+
+  @Get('simulado')
+  @ApiBearerAuth()
+  @UseGuards(PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.visualizarTurmas)
+  @ApiResponse({ status: 200, type: ListMonthsDtoOutput })
+  async listMonths(@Param('id') id: string, @Req() req: Request) {
+    return this.service.listMonths(id, (req.user as User).id);
+  }
+
+  @Get('simulado/:month')
+  @ApiBearerAuth()
+  @UseGuards(PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.visualizarTurmas)
+  @ApiResponse({ status: 200, type: MonthAnalyticsDtoOutput })
+  @ApiResponse({ status: 404 })
+  async getByMonth(
+    @Param('id') id: string,
+    @Param('month') month: string,
+    @Req() req: Request,
+  ) {
+    return this.service.getByMonth(id, month, (req.user as User).id);
+  }
+
+  @Post('simulado/refresh')
+  @HttpCode(202)
+  @ApiBearerAuth()
+  @UseGuards(PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.gerenciarTurmas)
+  @ApiResponse({ status: 202, type: RefreshDtoOutput })
+  async refresh(
+    @Param('id') id: string,
+    @Query('all') all: string,
+    @Req() req: Request,
+  ) {
+    const scope = all === 'true' ? 'all' : 'current';
+    return this.service.refresh(id, scope, (req.user as User).id);
+  }
+}

--- a/src/modules/prepCourse/class/analytics/class-analytics.module.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { EnvModule } from 'src/shared/modules/env/env.module';
+import { HttpServiceAxiosFactory } from 'src/shared/services/axios/http-service-axios.factory';
+import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
+import { ClassModule } from '../class.module';
+import { ClassAnalyticsController } from './class-analytics.controller';
+import { ClassAnalyticsService } from './class-analytics.service';
+
+@Module({
+  imports: [ClassModule, EnvModule],
+  controllers: [ClassAnalyticsController],
+  providers: [ClassAnalyticsService, SimuladoHttpService, HttpServiceAxiosFactory],
+})
+export class ClassAnalyticsModule {}

--- a/src/modules/prepCourse/class/analytics/class-analytics.module.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.module.ts
@@ -1,6 +1,5 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
-import { UserModule } from 'src/modules/user/user.module';
 import { EnvModule } from 'src/shared/modules/env/env.module';
 import { HttpServiceAxiosFactory } from 'src/shared/services/axios/http-service-axios.factory';
 import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
@@ -9,7 +8,7 @@ import { ClassAnalyticsController } from './class-analytics.controller';
 import { ClassAnalyticsService } from './class-analytics.service';
 
 @Module({
-  imports: [ClassModule, EnvModule, UserModule, HttpModule],
+  imports: [ClassModule, EnvModule, HttpModule],
   controllers: [ClassAnalyticsController],
   providers: [ClassAnalyticsService, SimuladoHttpService, HttpServiceAxiosFactory],
 })

--- a/src/modules/prepCourse/class/analytics/class-analytics.module.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.module.ts
@@ -1,5 +1,6 @@
 import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
+import { UserModule } from 'src/modules/user/user.module';
 import { EnvModule } from 'src/shared/modules/env/env.module';
 import { HttpServiceAxiosFactory } from 'src/shared/services/axios/http-service-axios.factory';
 import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
@@ -8,7 +9,7 @@ import { ClassAnalyticsController } from './class-analytics.controller';
 import { ClassAnalyticsService } from './class-analytics.service';
 
 @Module({
-  imports: [ClassModule, EnvModule, HttpModule],
+  imports: [ClassModule, EnvModule, UserModule, HttpModule],
   controllers: [ClassAnalyticsController],
   providers: [ClassAnalyticsService, SimuladoHttpService, HttpServiceAxiosFactory],
 })

--- a/src/modules/prepCourse/class/analytics/class-analytics.module.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.module.ts
@@ -1,4 +1,6 @@
+import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
+import { UserModule } from 'src/modules/user/user.module';
 import { EnvModule } from 'src/shared/modules/env/env.module';
 import { HttpServiceAxiosFactory } from 'src/shared/services/axios/http-service-axios.factory';
 import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
@@ -7,7 +9,7 @@ import { ClassAnalyticsController } from './class-analytics.controller';
 import { ClassAnalyticsService } from './class-analytics.service';
 
 @Module({
-  imports: [ClassModule, EnvModule],
+  imports: [ClassModule, EnvModule, UserModule, HttpModule],
   controllers: [ClassAnalyticsController],
   providers: [ClassAnalyticsService, SimuladoHttpService, HttpServiceAxiosFactory],
 })

--- a/src/modules/prepCourse/class/analytics/class-analytics.service.spec.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.service.spec.ts
@@ -1,0 +1,193 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { StatusApplication } from '../../studentCourse/enums/stastusApplication';
+import { ClassAnalyticsService } from './class-analytics.service';
+import { ClassService } from '../class.service';
+import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
+
+const ACTIVE_START = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // 30 days ago
+const ACTIVE_END = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days from now
+const PAST_END = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000); // 10 days ago (ended)
+
+function makeClass(overrides: Partial<any> = {}): any {
+  return {
+    id: 'class-1',
+    name: 'Turma A',
+    coursePeriodStartDate: ACTIVE_START,
+    coursePeriodEndDate: ACTIVE_END,
+    students: [
+      {
+        id: 'sc-1',
+        userId: 'user-1',
+        status: StatusApplication.Enrolled,
+      },
+      {
+        id: 'sc-2',
+        userId: 'user-2',
+        status: StatusApplication.UnderReview,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('ClassAnalyticsService', () => {
+  let service: ClassAnalyticsService;
+  let classService: jest.Mocked<ClassService>;
+  let simuladoHttp: jest.Mocked<SimuladoHttpService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClassAnalyticsService,
+        {
+          provide: ClassService,
+          useValue: {
+            findOneById: jest.fn(),
+          },
+        },
+        {
+          provide: SimuladoHttpService,
+          useValue: {
+            listUserGroupAggregates: jest.fn(),
+            getUserGroupAggregateByMonth: jest.fn(),
+            calculateUserGroupAggregate: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(ClassAnalyticsService);
+    classService = module.get(ClassService) as jest.Mocked<ClassService>;
+    simuladoHttp = module.get(SimuladoHttpService) as jest.Mocked<SimuladoHttpService>;
+  });
+
+  // ── listMonths ──────────────────────────────────────────────────────────────
+
+  describe('listMonths', () => {
+    it('returns months: [] when ms-simulado returns empty array', async () => {
+      classService.findOneById.mockResolvedValue(makeClass());
+      simuladoHttp.listUserGroupAggregates.mockResolvedValue([]);
+
+      const result = await service.listMonths('class-1', 'requester-1');
+
+      expect(result.months).toEqual([]);
+      expect(result.classId).toBe('class-1');
+      expect(result.className).toBe('Turma A');
+      expect(result.totalStudents).toBe(2);
+    });
+
+    it('maps ms-simulado documents correctly to output', async () => {
+      const now = new Date().toISOString();
+      const doc = {
+        month: '2025-01',
+        monthStart: '2025-01-01T00:00:00.000Z',
+        monthEnd: '2025-01-31T23:59:59.000Z',
+        payload: {
+          geral: { average: 0.65, total: 10 },
+          studentsWithAtLeastOneCompletedAttempt: 5,
+          totalAttemptsCompleted: 20,
+        },
+        generatedAt: now,
+      };
+
+      classService.findOneById.mockResolvedValue(makeClass());
+      simuladoHttp.listUserGroupAggregates.mockResolvedValue([doc]);
+
+      const result = await service.listMonths('class-1', 'requester-1');
+
+      expect(result.months).toHaveLength(1);
+      const m = result.months[0];
+      expect(m.month).toBe('2025-01');
+      expect(m.monthStart).toBe(doc.monthStart);
+      expect(m.monthEnd).toBe(doc.monthEnd);
+      expect(m.geral).toEqual(doc.payload.geral);
+      expect(m.studentsWithAtLeastOneCompletedAttempt).toBe(5);
+      expect(m.totalAttemptsCompleted).toBe(20);
+      expect(m.generatedAt).toBe(now);
+    });
+  });
+
+  // ── getByMonth ──────────────────────────────────────────────────────────────
+
+  describe('getByMonth', () => {
+    it('throws NotFoundException when ms-simulado returns null', async () => {
+      classService.findOneById.mockResolvedValue(makeClass());
+      simuladoHttp.getUserGroupAggregateByMonth.mockResolvedValue(null);
+
+      await expect(
+        service.getByMonth('class-1', '2025-01', 'requester-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns merged data when ms-simulado returns a document', async () => {
+      const now = new Date().toISOString();
+      const doc = {
+        month: '2025-01',
+        monthStart: '2025-01-01T00:00:00.000Z',
+        monthEnd: '2025-01-31T23:59:59.000Z',
+        payload: {
+          geral: { average: 0.7 },
+          studentsWithAtLeastOneCompletedAttempt: 3,
+          totalAttemptsCompleted: 9,
+        },
+        generatedAt: now,
+      };
+
+      classService.findOneById.mockResolvedValue(makeClass());
+      simuladoHttp.getUserGroupAggregateByMonth.mockResolvedValue(doc);
+
+      const result = await service.getByMonth('class-1', '2025-01', 'requester-1');
+
+      expect(result.classId).toBe('class-1');
+      expect(result.className).toBe('Turma A');
+      expect(result.month).toBe('2025-01');
+      expect(result.monthStart).toBe(doc.monthStart);
+      expect(result.monthEnd).toBe(doc.monthEnd);
+      expect(result.geral).toEqual(doc.payload.geral);
+      expect(result.generatedAt).toBe(now);
+    });
+  });
+
+  // ── refresh ─────────────────────────────────────────────────────────────────
+
+  describe('refresh', () => {
+    it('with scope=current calls calculateUserGroupAggregate exactly once', async () => {
+      classService.findOneById.mockResolvedValue(makeClass());
+      simuladoHttp.calculateUserGroupAggregate.mockResolvedValue({});
+
+      const result = await service.refresh('class-1', 'current', 'requester-1');
+
+      expect(simuladoHttp.calculateUserGroupAggregate).toHaveBeenCalledTimes(1);
+      expect(result.enqueued).toHaveLength(1);
+      expect(result.estimatedSeconds).toBe(1);
+    });
+
+    it('throws BadRequestException when class period has ended', async () => {
+      classService.findOneById.mockResolvedValue(
+        makeClass({
+          coursePeriodStartDate: new Date('2020-01-01'),
+          coursePeriodEndDate: PAST_END,
+        }),
+      );
+
+      await expect(
+        service.refresh('class-1', 'current', 'requester-1'),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(simuladoHttp.calculateUserGroupAggregate).not.toHaveBeenCalled();
+    });
+
+    it('only includes userIds of students with status Enrolled', async () => {
+      classService.findOneById.mockResolvedValue(makeClass());
+      simuladoHttp.calculateUserGroupAggregate.mockResolvedValue({});
+
+      await service.refresh('class-1', 'current', 'requester-1');
+
+      const callArgs = simuladoHttp.calculateUserGroupAggregate.mock.calls[0][0];
+      // Only user-1 is Enrolled; user-2 is UnderReview
+      expect(callArgs.userIds).toEqual(['user-1']);
+      expect(callArgs.userIds).not.toContain('user-2');
+    });
+  });
+});

--- a/src/modules/prepCourse/class/analytics/class-analytics.service.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.service.ts
@@ -1,0 +1,111 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { ClassService } from '../class.service';
+import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
+import { StatusApplication } from '../../studentCourse/enums/stastusApplication';
+import {
+  computeMonthWindow,
+  isActivePeriod,
+  listMonthsInPeriod,
+} from './utils/month-window';
+
+@Injectable()
+export class ClassAnalyticsService {
+  constructor(
+    private readonly classService: ClassService,
+    private readonly simuladoHttp: SimuladoHttpService,
+  ) {}
+
+  async listMonths(classId: string, requesterId: string) {
+    const klass = await this.classService.findOneById(classId, requesterId);
+    if (!klass.coursePeriodStartDate) {
+      throw new BadRequestException('Class has no course period');
+    }
+
+    const period = {
+      startDate: new Date(klass.coursePeriodStartDate),
+      endDate: new Date(klass.coursePeriodEndDate),
+    };
+
+    const docs = await this.simuladoHttp.listUserGroupAggregates(classId);
+
+    return {
+      classId: klass.id,
+      className: klass.name,
+      coursePeriod: {
+        startDate: period.startDate,
+        endDate: period.endDate,
+        isActive: isActivePeriod(period),
+      },
+      totalStudents: klass.students?.length ?? 0,
+      months: (docs as any[]).map((d) => ({
+        month: d.month,
+        monthStart: d.monthStart,
+        monthEnd: d.monthEnd,
+        geral: d.payload.geral,
+        studentsWithAtLeastOneCompletedAttempt:
+          d.payload.studentsWithAtLeastOneCompletedAttempt,
+        totalAttemptsCompleted: d.payload.totalAttemptsCompleted,
+        generatedAt: d.generatedAt,
+      })),
+    };
+  }
+
+  async getByMonth(classId: string, month: string, requesterId: string) {
+    const klass = await this.classService.findOneById(classId, requesterId);
+    const doc = await this.simuladoHttp.getUserGroupAggregateByMonth(
+      classId,
+      month,
+    );
+    if (!doc) throw new NotFoundException('Snapshot not generated for this month');
+
+    return {
+      classId: klass.id,
+      className: klass.name,
+      month: doc.month,
+      monthStart: doc.monthStart,
+      monthEnd: doc.monthEnd,
+      ...doc.payload,
+      generatedAt: doc.generatedAt,
+    };
+  }
+
+  async refresh(classId: string, scope: 'current' | 'all', requesterId: string) {
+    const klass = await this.classService.findOneById(classId, requesterId);
+    if (!klass.coursePeriodStartDate) {
+      throw new BadRequestException('Class has no course period');
+    }
+
+    const period = {
+      startDate: new Date(klass.coursePeriodStartDate),
+      endDate: new Date(klass.coursePeriodEndDate),
+    };
+
+    if (!isActivePeriod(period)) {
+      throw new BadRequestException('Period not active');
+    }
+
+    const allMonths = listMonthsInPeriod(period);
+    const monthsToRefresh =
+      scope === 'all' ? allMonths : [allMonths[allMonths.length - 1]];
+
+    const enrolledUserIds = (klass.students ?? [])
+      .filter((s) => s.status === StatusApplication.Enrolled)
+      .map((s) => s.userId);
+
+    for (const month of monthsToRefresh) {
+      const { monthStart, monthEnd } = computeMonthWindow(month, period);
+      await this.simuladoHttp.calculateUserGroupAggregate({
+        groupId: classId,
+        month,
+        monthStart,
+        monthEnd,
+        userIds: enrolledUserIds,
+      });
+    }
+
+    return {
+      enqueued: monthsToRefresh.map((m) => ({ classId, month: m })),
+      estimatedSeconds: monthsToRefresh.length,
+    };
+  }
+}

--- a/src/modules/prepCourse/class/analytics/dtos/list-months.dto.output.ts
+++ b/src/modules/prepCourse/class/analytics/dtos/list-months.dto.output.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MonthSummary {
+  @ApiProperty() month: string;
+  @ApiProperty() monthStart: Date;
+  @ApiProperty() monthEnd: Date;
+  @ApiProperty() geral: number;
+  @ApiProperty() studentsWithAtLeastOneCompletedAttempt: number;
+  @ApiProperty() totalAttemptsCompleted: number;
+  @ApiProperty() generatedAt: Date;
+}
+
+export class CoursePeriodInfo {
+  @ApiProperty() startDate: Date;
+  @ApiProperty() endDate: Date;
+  @ApiProperty() isActive: boolean;
+}
+
+export class ListMonthsDtoOutput {
+  @ApiProperty() classId: string;
+  @ApiProperty() className: string;
+  @ApiProperty() coursePeriod: CoursePeriodInfo;
+  @ApiProperty() totalStudents: number;
+  @ApiProperty({ type: [MonthSummary] }) months: MonthSummary[];
+}

--- a/src/modules/prepCourse/class/analytics/dtos/month-analytics.dto.output.ts
+++ b/src/modules/prepCourse/class/analytics/dtos/month-analytics.dto.output.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FrenteAnalytics {
+  @ApiProperty() id: string;
+  @ApiProperty() nome: string;
+  @ApiProperty() aproveitamento: number;
+  @ApiProperty() studentsContributing: number;
+  @ApiProperty() attemptsContributing: number;
+}
+
+export class MateriaAnalytics {
+  @ApiProperty() id: string;
+  @ApiProperty() nome: string;
+  @ApiProperty() aproveitamento: number;
+  @ApiProperty() studentsContributing: number;
+  @ApiProperty() attemptsContributing: number;
+  @ApiProperty({ type: [FrenteAnalytics] }) frentes: FrenteAnalytics[];
+}
+
+export class MonthAnalyticsDtoOutput {
+  @ApiProperty() classId: string;
+  @ApiProperty() className: string;
+  @ApiProperty() month: string;
+  @ApiProperty() monthStart: Date;
+  @ApiProperty() monthEnd: Date;
+  @ApiProperty() geral: number;
+  @ApiProperty() totalAttempts: number;
+  @ApiProperty() totalAttemptsCompleted: number;
+  @ApiProperty() studentsWithAtLeastOneCompletedAttempt: number;
+  @ApiProperty() generatedAt: Date;
+  @ApiProperty({ type: [MateriaAnalytics] }) materias: MateriaAnalytics[];
+}

--- a/src/modules/prepCourse/class/analytics/dtos/refresh.dto.output.ts
+++ b/src/modules/prepCourse/class/analytics/dtos/refresh.dto.output.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class EnqueuedItem {
+  @ApiProperty() classId: string;
+  @ApiProperty() month: string;
+}
+
+export class RefreshDtoOutput {
+  @ApiProperty({ type: [EnqueuedItem] }) enqueued: EnqueuedItem[];
+  @ApiProperty() estimatedSeconds: number;
+}

--- a/src/modules/prepCourse/class/analytics/utils/month-window.spec.ts
+++ b/src/modules/prepCourse/class/analytics/utils/month-window.spec.ts
@@ -1,0 +1,126 @@
+import {
+  computeMonthWindow,
+  CoursePeriodBounds,
+  listMonthsInPeriod,
+  isActivePeriod,
+} from './month-window';
+
+describe('month-window utilities', () => {
+  describe('computeMonthWindow', () => {
+    const period: CoursePeriodBounds = {
+      startDate: new Date(Date.UTC(2026, 1, 23, 0, 0, 0)), // 2026-02-23
+      endDate: new Date(Date.UTC(2026, 11, 15, 23, 59, 59)), // 2026-12-15
+    };
+
+    it('should truncate month start if period starts after month start', () => {
+      const result = computeMonthWindow('2026-02', period);
+      expect(result.monthStart).toEqual(
+        new Date(Date.UTC(2026, 1, 23, 0, 0, 0)),
+      );
+    });
+
+    it('should truncate month end if period ends before month end', () => {
+      const result = computeMonthWindow('2026-12', period);
+      expect(result.monthEnd).toEqual(
+        new Date(Date.UTC(2026, 11, 15, 23, 59, 59)),
+      );
+    });
+
+    it('should return full month when period contains entire month', () => {
+      const result = computeMonthWindow('2026-06', period);
+      expect(result.monthStart).toEqual(
+        new Date(Date.UTC(2026, 5, 1, 0, 0, 0)),
+      );
+      expect(result.monthEnd).toEqual(
+        new Date(Date.UTC(2026, 5, 30, 23, 59, 59)),
+      );
+    });
+  });
+
+  describe('listMonthsInPeriod', () => {
+    const period: CoursePeriodBounds = {
+      startDate: new Date(Date.UTC(2026, 1, 23, 0, 0, 0)), // 2026-02-23
+      endDate: new Date(Date.UTC(2026, 11, 15, 23, 59, 59)), // 2026-12-15
+    };
+
+    it('should list months from period start until today', () => {
+      const today = new Date(Date.UTC(2026, 4, 16, 12, 0, 0)); // 2026-05-16
+      const result = listMonthsInPeriod(period, today);
+      expect(result).toEqual(['2026-02', '2026-03', '2026-04', '2026-05']);
+    });
+
+    it('should cap at period end date if it is before today', () => {
+      const today = new Date(Date.UTC(2027, 0, 1, 0, 0, 0)); // 2027-01-01
+      const result = listMonthsInPeriod(period, today);
+      expect(result).toContain('2026-12');
+      expect(result.every((m) => m.startsWith('2026-'))).toBe(true);
+    });
+
+    it('should work with period that ends before period.endDate', () => {
+      const periodShort: CoursePeriodBounds = {
+        startDate: new Date(Date.UTC(2026, 0, 1, 0, 0, 0)), // 2026-01-01
+        endDate: new Date(Date.UTC(2026, 2, 31, 23, 59, 59)), // 2026-03-31
+      };
+      const today = new Date(Date.UTC(2026, 5, 16, 12, 0, 0)); // 2026-06-16
+      const result = listMonthsInPeriod(periodShort, today);
+      expect(result).toEqual(['2026-01', '2026-02', '2026-03']);
+    });
+
+    it('should return empty array if period start is after today', () => {
+      const periodFuture: CoursePeriodBounds = {
+        startDate: new Date(Date.UTC(2026, 5, 1, 0, 0, 0)), // 2026-06-01
+        endDate: new Date(Date.UTC(2026, 11, 31, 23, 59, 59)), // 2026-12-31
+      };
+      const today = new Date(Date.UTC(2026, 4, 16, 12, 0, 0)); // 2026-05-16
+      const result = listMonthsInPeriod(periodFuture, today);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('isActivePeriod', () => {
+    it('should return true if today is within period', () => {
+      const period: CoursePeriodBounds = {
+        startDate: new Date(Date.UTC(2026, 1, 1, 0, 0, 0)),
+        endDate: new Date(Date.UTC(2026, 11, 31, 23, 59, 59)),
+      };
+      const today = new Date(Date.UTC(2026, 4, 16, 12, 0, 0)); // 2026-05-16
+      expect(isActivePeriod(period, today)).toBe(true);
+    });
+
+    it('should return false if today is before period start', () => {
+      const period: CoursePeriodBounds = {
+        startDate: new Date(Date.UTC(2026, 5, 1, 0, 0, 0)),
+        endDate: new Date(Date.UTC(2026, 11, 31, 23, 59, 59)),
+      };
+      const today = new Date(Date.UTC(2026, 4, 16, 12, 0, 0)); // 2026-05-16
+      expect(isActivePeriod(period, today)).toBe(false);
+    });
+
+    it('should return false if today is after period end', () => {
+      const period: CoursePeriodBounds = {
+        startDate: new Date(Date.UTC(2026, 1, 1, 0, 0, 0)),
+        endDate: new Date(Date.UTC(2026, 3, 31, 23, 59, 59)),
+      };
+      const today = new Date(Date.UTC(2026, 4, 16, 12, 0, 0)); // 2026-05-16
+      expect(isActivePeriod(period, today)).toBe(false);
+    });
+
+    it('should return true if today equals period start', () => {
+      const period: CoursePeriodBounds = {
+        startDate: new Date(Date.UTC(2026, 4, 16, 12, 0, 0)),
+        endDate: new Date(Date.UTC(2026, 11, 31, 23, 59, 59)),
+      };
+      const today = new Date(Date.UTC(2026, 4, 16, 12, 0, 0));
+      expect(isActivePeriod(period, today)).toBe(true);
+    });
+
+    it('should return true if today equals period end', () => {
+      const period: CoursePeriodBounds = {
+        startDate: new Date(Date.UTC(2026, 1, 1, 0, 0, 0)),
+        endDate: new Date(Date.UTC(2026, 4, 16, 12, 0, 0)),
+      };
+      const today = new Date(Date.UTC(2026, 4, 16, 12, 0, 0));
+      expect(isActivePeriod(period, today)).toBe(true);
+    });
+  });
+});

--- a/src/modules/prepCourse/class/analytics/utils/month-window.ts
+++ b/src/modules/prepCourse/class/analytics/utils/month-window.ts
@@ -1,0 +1,45 @@
+export interface CoursePeriodBounds {
+  startDate: Date;
+  endDate: Date;
+}
+
+export function computeMonthWindow(
+  month: string,
+  period: CoursePeriodBounds,
+): { monthStart: Date; monthEnd: Date } {
+  const [year, m] = month.split('-').map(Number);
+  const naiveStart = new Date(Date.UTC(year, m - 1, 1, 0, 0, 0));
+  const naiveEnd = new Date(Date.UTC(year, m, 0, 23, 59, 59));
+  const start = period.startDate > naiveStart ? period.startDate : naiveStart;
+  const end = period.endDate < naiveEnd ? period.endDate : naiveEnd;
+  return { monthStart: start, monthEnd: end };
+}
+
+export function listMonthsInPeriod(
+  period: CoursePeriodBounds,
+  today = new Date(),
+): string[] {
+  const cap = period.endDate < today ? period.endDate : today;
+  const out: string[] = [];
+  const cursor = new Date(
+    Date.UTC(
+      period.startDate.getUTCFullYear(),
+      period.startDate.getUTCMonth(),
+      1,
+    ),
+  );
+  while (cursor <= cap) {
+    out.push(
+      `${cursor.getUTCFullYear()}-${String(cursor.getUTCMonth() + 1).padStart(2, '0')}`,
+    );
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+  }
+  return out;
+}
+
+export function isActivePeriod(
+  period: CoursePeriodBounds,
+  today = new Date(),
+): boolean {
+  return today >= period.startDate && today <= period.endDate;
+}

--- a/src/modules/prepCourse/class/class.service.ts
+++ b/src/modules/prepCourse/class/class.service.ts
@@ -105,6 +105,7 @@ export class ClassService extends BaseService<Class> {
         const students = classEntity.students.map((student) => {
           return {
             id: student.id,
+            userId: student.userId,
             name: student.user.useSocialName
               ? `${student.user.socialName?.split(' ')[0]} ${student.user.lastName}`
               : `${student.user.firstName} ${student.user.lastName}`,

--- a/src/modules/prepCourse/class/dtos/get-class-by-id.dto.output.ts
+++ b/src/modules/prepCourse/class/dtos/get-class-by-id.dto.output.ts
@@ -17,6 +17,7 @@ export class GetClassByIdDtoOutput {
 
 export class StudentClass {
   id: string;
+  userId: string;
   name: string;
   email: string;
   status: StatusApplication;

--- a/src/shared/services/simulado-http.service.ts
+++ b/src/shared/services/simulado-http.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { EnvService } from 'src/shared/modules/env/env.service';
+import {
+  HttpServiceAxios,
+  HttpServiceAxiosFactory,
+} from 'src/shared/services/axios/http-service-axios.factory';
+
+@Injectable()
+export class SimuladoHttpService {
+  private readonly axios: HttpServiceAxios;
+
+  constructor(
+    private readonly httpServiceFactory: HttpServiceAxiosFactory,
+    private readonly envService: EnvService,
+  ) {
+    this.axios = this.httpServiceFactory.create(
+      this.envService.get('SIMULADO_URL'),
+    );
+  }
+
+  async listUserGroupAggregates(groupId: string): Promise<any[]> {
+    return this.axios.get(`v1/user-group-aggregates?groupId=${groupId}&groupType=class`);
+  }
+
+  async getUserGroupAggregateByMonth(
+    groupId: string,
+    month: string,
+  ): Promise<any | null> {
+    try {
+      return await this.axios.get(
+        `v1/user-group-aggregates/by-month?groupId=${groupId}&groupType=class&month=${month}`,
+      );
+    } catch (err: any) {
+      if (err?.response?.status === 404 || err?.status === 404) return null;
+      throw err;
+    }
+  }
+
+  async calculateUserGroupAggregate(payload: {
+    groupId: string;
+    month: string;
+    monthStart: Date;
+    monthEnd: Date;
+    userIds: string[];
+  }): Promise<any> {
+    return this.axios.post(`v1/user-group-aggregates/calculate`, {
+      groupType: 'class',
+      ...payload,
+    });
+  }
+}

--- a/test/class-analytics.e2e-spec.ts
+++ b/test/class-analytics.e2e-spec.ts
@@ -1,0 +1,393 @@
+import { INestApplication } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { AppModule } from 'src/app.module';
+import { GeoService } from 'src/modules/geo/geo.service';
+import { LogGeoRepository } from 'src/modules/geo/log-geo/log-geo.repository';
+import { ClassRepository } from 'src/modules/prepCourse/class/class.repository';
+import { CoursePeriodService } from 'src/modules/prepCourse/coursePeriod/course-period.service';
+import { PartnerPrepCourseDtoInput } from 'src/modules/prepCourse/partnerPrepCourse/dtos/create-partner-prep-course.input.dto';
+import { LogPartnerRepository } from 'src/modules/prepCourse/partnerPrepCourse/log-partner/log-partner.repository';
+import { PartnerPrepCourseService } from 'src/modules/prepCourse/partnerPrepCourse/partner-prep-course.service';
+import { CreateRoleDtoInput } from 'src/modules/role/dto/create-role.dto';
+import { Role } from 'src/modules/role/role.entity';
+import { RoleService } from 'src/modules/role/role.service';
+import { UserRepository } from 'src/modules/user/user.repository';
+import { UserService } from 'src/modules/user/user.service';
+import { FormService } from 'src/modules/vcnafacul-form/form/form.service';
+import { BlobService } from 'src/shared/services/blob/blob-service';
+import { EmailService } from 'src/shared/services/email/email.service';
+import { HttpServiceAxiosFactory } from 'src/shared/services/axios/http-service-axios.factory';
+import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
+import { DiscordWebhook } from 'src/shared/services/webhooks/discord';
+import * as request from 'supertest';
+import { CreateCoursePeriodDtoInputFaker } from './faker/create-course-period.dto.input.faker';
+import { CreateGeoDTOInputFaker } from './faker/create-geo.dto.input.faker';
+import { CreateUserDtoInputFaker } from './faker/create-user.dto.input.faker';
+import { createNestAppTest } from './utils/createNestAppTest';
+
+jest.mock('src/shared/services/email/email.service');
+jest.mock('src/shared/services/blob/blob-service.ts');
+jest.mock('src/shared/services/webhooks/discord.ts');
+
+describe('ClassAnalytics (e2e)', () => {
+  let app: INestApplication;
+  let userService: UserService;
+  let userRepository: UserRepository;
+  let geoService: GeoService;
+  let jwtService: JwtService;
+  let roleService: RoleService;
+  let partnerService: PartnerPrepCourseService;
+  let emailService: EmailService;
+  let classRepository: ClassRepository;
+  let coursePeriodService: CoursePeriodService;
+  let blobService: BlobService;
+  let logPartnerRepository: LogPartnerRepository;
+  let logGeoRepository: LogGeoRepository;
+
+  // Role with both gerenciarTurmas and visualizarTurmas
+  let analyticsRole: Role = null;
+
+  const discordWebhookMock = {
+    sendMessage: jest.fn(),
+  };
+
+  const formServiceMock = {
+    hasActiveForm: jest.fn().mockResolvedValue(true),
+    createFormFull: jest.fn().mockResolvedValue('hashKeyFile'),
+    getFormFullByInscriptionId: jest.fn().mockResolvedValue('hashKeyFile'),
+    createPartnerForm: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const simuladoHttpMock = {
+    listUserGroupAggregates: jest.fn().mockResolvedValue([]),
+    getUserGroupAggregateByMonth: jest.fn().mockResolvedValue(null),
+    calculateUserGroupAggregate: jest.fn().mockResolvedValue({}),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+      providers: [EmailService],
+    })
+      .overrideProvider(DiscordWebhook)
+      .useValue(discordWebhookMock)
+      .overrideProvider(FormService)
+      .useValue(formServiceMock)
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .overrideProvider(SimuladoHttpService)
+      .useValue(simuladoHttpMock)
+      .overrideProvider(HttpServiceAxiosFactory)
+      .useValue({ create: () => ({}) })
+      .compile();
+
+    app = createNestAppTest(moduleFixture);
+    userService = moduleFixture.get<UserService>(UserService);
+    userRepository = moduleFixture.get<UserRepository>(UserRepository);
+    geoService = moduleFixture.get<GeoService>(GeoService);
+    jwtService = moduleFixture.get<JwtService>(JwtService);
+    roleService = moduleFixture.get<RoleService>(RoleService);
+    emailService = moduleFixture.get<EmailService>(EmailService);
+    partnerService = moduleFixture.get<PartnerPrepCourseService>(
+      PartnerPrepCourseService,
+    );
+    classRepository = moduleFixture.get<ClassRepository>(ClassRepository);
+    coursePeriodService =
+      moduleFixture.get<CoursePeriodService>(CoursePeriodService);
+    blobService = moduleFixture.get<BlobService>('BlobService');
+    logPartnerRepository =
+      moduleFixture.get<LogPartnerRepository>(LogPartnerRepository);
+    logGeoRepository = moduleFixture.get<LogGeoRepository>(LogGeoRepository);
+
+    jest.spyOn(emailService, 'sendEmailGeo').mockImplementation(async () => {});
+    jest
+      .spyOn(emailService, 'sendCreateUser')
+      .mockImplementation(async () => {});
+    jest
+      .spyOn(blobService, 'uploadFile')
+      .mockImplementation(async () => 'hashKeyFile');
+    jest
+      .spyOn(blobService, 'getFile')
+      .mockImplementation(async () => Buffer.from('fake'));
+    jest
+      .spyOn(logPartnerRepository, 'create')
+      .mockImplementation(async () => ({}) as any);
+    jest
+      .spyOn(logGeoRepository, 'create')
+      .mockImplementation(async () => ({}) as any);
+
+    await app.init();
+
+    // Role com gerenciarTurmas + visualizarTurmas (para analytics)
+    analyticsRole = await roleService.findOneBy({
+      name: 'custom_role_analytics',
+    });
+    if (!analyticsRole) {
+      const newRole = new CreateRoleDtoInput();
+      newRole.name = 'custom_role_analytics';
+      newRole.gerenciarTurmas = true;
+      newRole.visualizarTurmas = true;
+      analyticsRole = await roleService.create(newRole);
+    }
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Re-apply default mock implementations after clearAllMocks
+    simuladoHttpMock.listUserGroupAggregates.mockResolvedValue([]);
+    simuladoHttpMock.getUserGroupAggregateByMonth.mockResolvedValue(null);
+    simuladoHttpMock.calculateUserGroupAggregate.mockResolvedValue({});
+  });
+
+  /**
+   * Creates a partner + user with analyticsRole
+   */
+  const createPartnerWithAnalyticsRole = async () => {
+    const geoDto = CreateGeoDTOInputFaker();
+    const geo = await geoService.create(geoDto);
+
+    const userDto = CreateUserDtoInputFaker();
+    await userService.create(userDto);
+    const user = await userRepository.findOneBy({ email: userDto.email });
+
+    user.role = analyticsRole;
+    await userRepository.update(user);
+
+    const dto: PartnerPrepCourseDtoInput = {
+      geoId: geo.id,
+      representative: user.id,
+    };
+    const partner = await partnerService.create(dto, user.id);
+    return { user, partner };
+  };
+
+  /**
+   * Creates a user without any special permissions (no role)
+   */
+  const createUnprivilegedUser = async () => {
+    const userDto = CreateUserDtoInputFaker();
+    await userService.create(userDto);
+    return userRepository.findOneBy({ email: userDto.email });
+  };
+
+  /**
+   * Creates a class with an ACTIVE course period (startDate <= today <= endDate)
+   */
+  const createClassWithActivePeriod = async (userId: string) => {
+    const today = new Date();
+    const startDate = new Date(today);
+    startDate.setMonth(startDate.getMonth() - 3); // 3 months ago
+    const endDate = new Date(today);
+    endDate.setMonth(endDate.getMonth() + 9); // 9 months from now
+
+    const coursePeriod = await coursePeriodService.create(
+      {
+        name: `Período Ativo ${Date.now()}`,
+        startDate,
+        endDate,
+      },
+      userId,
+    );
+
+    const classDto = {
+      name: `Turma Analytics ${Date.now()}`,
+      description: 'Turma de teste analytics',
+      coursePeriodId: coursePeriod.id,
+    };
+
+    const createdClass = await request(app.getHttpServer())
+      .post('/class')
+      .send(classDto)
+      .set({
+        Authorization: `Bearer ${await jwtService.signAsync(
+          { user: { id: userId } },
+          { expiresIn: '2h' },
+        )}`,
+      })
+      .expect(201);
+
+    return { classId: createdClass.body.id as string, coursePeriod };
+  };
+
+  /**
+   * Creates a class with an ENDED course period (endDate < today)
+   */
+  const createClassWithEndedPeriod = async (userId: string) => {
+    const today = new Date();
+    const startDate = new Date(today);
+    startDate.setFullYear(startDate.getFullYear() - 2); // 2 years ago
+    const endDate = new Date(today);
+    endDate.setMonth(endDate.getMonth() - 1); // 1 month ago
+
+    const coursePeriod = await coursePeriodService.create(
+      {
+        name: `Período Encerrado ${Date.now()}`,
+        startDate,
+        endDate,
+      },
+      userId,
+    );
+
+    const classDto = {
+      name: `Turma Encerrada ${Date.now()}`,
+      description: 'Turma de teste período encerrado',
+      coursePeriodId: coursePeriod.id,
+    };
+
+    const createdClass = await request(app.getHttpServer())
+      .post('/class')
+      .send(classDto)
+      .set({
+        Authorization: `Bearer ${await jwtService.signAsync(
+          { user: { id: userId } },
+          { expiresIn: '2h' },
+        )}`,
+      })
+      .expect(201);
+
+    return { classId: createdClass.body.id as string, coursePeriod };
+  };
+
+  // ─── Cenário 1: 401 sem token / 403 sem permissão ─────────────────────────
+
+  it('should return 403 when no bearer token is provided', async () => {
+    return request(app.getHttpServer())
+      .get('/class/some-class-id/analytics/simulado')
+      .expect(403);
+  });
+
+  it('should return 403 when user lacks visualizarTurmas permission', async () => {
+    const unprivileged = await createUnprivilegedUser();
+    const token = await jwtService.signAsync(
+      { user: { id: unprivileged.id } },
+      { expiresIn: '2h' },
+    );
+
+    return request(app.getHttpServer())
+      .get('/class/some-class-id/analytics/simulado')
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(403);
+  }, 30000);
+
+  // ─── Cenário 2: 200 com lista vazia ───────────────────────────────────────
+
+  it('should return 200 with empty months list when simulado returns []', async () => {
+    const { user } = await createPartnerWithAnalyticsRole();
+    const token = await jwtService.signAsync(
+      { user: { id: user.id } },
+      { expiresIn: '2h' },
+    );
+
+    const { classId } = await createClassWithActivePeriod(user.id);
+
+    simuladoHttpMock.listUserGroupAggregates.mockResolvedValue([]);
+
+    const response = await request(app.getHttpServer())
+      .get(`/class/${classId}/analytics/simulado`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(200);
+
+    expect(response.body.months).toEqual([]);
+    expect(response.body.coursePeriod).toBeDefined();
+    expect(response.body.coursePeriod.isActive).toBe(true);
+  }, 30000);
+
+  // ─── Cenário 3: 404 mês não encontrado ────────────────────────────────────
+
+  it('should return 404 when simulado returns null for the requested month', async () => {
+    const { user } = await createPartnerWithAnalyticsRole();
+    const token = await jwtService.signAsync(
+      { user: { id: user.id } },
+      { expiresIn: '2h' },
+    );
+
+    const { classId } = await createClassWithActivePeriod(user.id);
+
+    simuladoHttpMock.getUserGroupAggregateByMonth.mockResolvedValue(null);
+
+    return request(app.getHttpServer())
+      .get(`/class/${classId}/analytics/simulado/2026-05`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(404);
+  }, 30000);
+
+  // ─── Cenário 4: 202 refresh current ───────────────────────────────────────
+
+  it('should return 202 and call calculateUserGroupAggregate once for current month refresh', async () => {
+    const { user } = await createPartnerWithAnalyticsRole();
+    const token = await jwtService.signAsync(
+      { user: { id: user.id } },
+      { expiresIn: '2h' },
+    );
+
+    const { classId } = await createClassWithActivePeriod(user.id);
+
+    simuladoHttpMock.calculateUserGroupAggregate.mockResolvedValue({});
+
+    const response = await request(app.getHttpServer())
+      .post(`/class/${classId}/analytics/simulado/refresh`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(202);
+
+    expect(simuladoHttpMock.calculateUserGroupAggregate).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(response.body.enqueued).toHaveLength(1);
+    expect(response.body.enqueued[0].classId).toBe(classId);
+  }, 30000);
+
+  // ─── Cenário 5: 202 refresh all ───────────────────────────────────────────
+
+  it('should return 202 and call calculateUserGroupAggregate N times for refresh?all=true', async () => {
+    const { user } = await createPartnerWithAnalyticsRole();
+    const token = await jwtService.signAsync(
+      { user: { id: user.id } },
+      { expiresIn: '2h' },
+    );
+
+    // Period starts 3 months ago → at least 3 months available
+    const { classId, coursePeriod } = await createClassWithActivePeriod(
+      user.id,
+    );
+
+    simuladoHttpMock.calculateUserGroupAggregate.mockResolvedValue({});
+
+    const response = await request(app.getHttpServer())
+      .post(`/class/${classId}/analytics/simulado/refresh?all=true`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(202);
+
+    const expectedMonths = response.body.enqueued.length;
+    expect(expectedMonths).toBeGreaterThan(1);
+    expect(simuladoHttpMock.calculateUserGroupAggregate).toHaveBeenCalledTimes(
+      expectedMonths,
+    );
+    response.body.enqueued.forEach((entry: { classId: string; month: string }) => {
+      expect(entry.classId).toBe(classId);
+      expect(entry.month).toMatch(/^\d{4}-\d{2}$/);
+    });
+  }, 30000);
+
+  // ─── Cenário 6: 400 período encerrado ─────────────────────────────────────
+
+  it('should return 400 when trying to refresh a class with an ended period', async () => {
+    const { user } = await createPartnerWithAnalyticsRole();
+    const token = await jwtService.signAsync(
+      { user: { id: user.id } },
+      { expiresIn: '2h' },
+    );
+
+    const { classId } = await createClassWithEndedPeriod(user.id);
+
+    return request(app.getHttpServer())
+      .post(`/class/${classId}/analytics/simulado/refresh`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(400);
+  }, 30000);
+});


### PR DESCRIPTION
## Summary

- Adds `ClassAnalyticsModule` to `api-vcnafacul` with three endpoints for the frontend:
  - `GET /class/:id/analytics/simulado` — lista meses com snapshots calculados (KPIs por mês)
  - `GET /class/:id/analytics/simulado/:month` — detalhe de um mês (matérias, frentes, aproveitamento)
  - `POST /class/:id/analytics/simulado/refresh` — dispara recálculo (síncrono nesta fase; Fase D adiciona fila)
- Adds `SimuladoHttpService` centralizado em `src/shared/services/` para chamadas ao ms-simulado
- Adds `month-window` utilities: `computeMonthWindow`, `listMonthsInPeriod`, `isActivePeriod`
- Adds `userId` to `StudentClass` DTO and maps it in `ClassService.findOneById`
- Refresh filtra apenas alunos com `StatusApplication.Enrolled`

## Context

**Fase B** of `turma-analytics-simulado`. Depends on [ms-simulado PR #142](https://github.com/vcnafacul/ms-simulado/pull/142) (Fase A, already merged). Frontend (Fase C) and queue/crons (Fase D) come next.

## Test Plan

- [ ] `npx jest --testPathPattern="month-window.spec" --no-coverage` — 12 unit tests pass
- [ ] `npx jest --testPathPattern="class-analytics.service.spec" --no-coverage` — 7 unit tests pass
- [ ] `npm run test -- class-analytics.e2e-spec.ts` — 7 E2E tests pass (requires Docker MySQL)
- [ ] `npm run build` — compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)