### PR TITLE
feat(class-analytics): queue + crons (Fase D)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ CACHE_DRIVER=inMemory
 REDIS_PORT= 6379
 REDIS_HOST='localhost'
 
+# Queue: 'memory' (in-memory, dev/homol) | 'redis' (prod)
+QUEUE_DRIVER=memory
+
 # Firebase (chat de suporte)
 FIREBASE_PROJECT_ID=
 FIREBASE_SERVICE_ACCOUNT_BASE64=

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "firebase-admin": "^13.8.0",
         "handlebars": "^4.7.8",
         "html-to-pdfmake": "^2.5.31",
+        "ioredis": "^5.10.1",
         "jsdom": "^27.0.0",
         "mammoth": "^1.9.0",
         "mysql2": "^3.12.0",
@@ -4429,6 +4430,12 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -13567,6 +13574,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -15176,6 +15207,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -17752,6 +17789,27 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -18804,6 +18862,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "firebase-admin": "^13.8.0",
     "handlebars": "^4.7.8",
     "html-to-pdfmake": "^2.5.31",
+    "ioredis": "^5.10.1",
     "jsdom": "^27.0.0",
     "mammoth": "^1.9.0",
     "mysql2": "^3.12.0",

--- a/src/modules/prepCourse/class/analytics/class-analytics.module.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.module.ts
@@ -2,15 +2,26 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { UserModule } from 'src/modules/user/user.module';
 import { EnvModule } from 'src/shared/modules/env/env.module';
+import { QueueModule } from 'src/shared/modules/queue/queue.module';
 import { HttpServiceAxiosFactory } from 'src/shared/services/axios/http-service-axios.factory';
 import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
 import { ClassModule } from '../class.module';
 import { ClassAnalyticsController } from './class-analytics.controller';
 import { ClassAnalyticsService } from './class-analytics.service';
+import { AnalyticsCronService } from './crons/analytics-cron.service';
+import { AnalyticsQueueService } from './queue/analytics-queue.service';
+import { AnalyticsWorkerService } from './queue/analytics-worker.service';
 
 @Module({
-  imports: [ClassModule, EnvModule, UserModule, HttpModule],
+  imports: [ClassModule, EnvModule, UserModule, HttpModule, QueueModule],
   controllers: [ClassAnalyticsController],
-  providers: [ClassAnalyticsService, SimuladoHttpService, HttpServiceAxiosFactory],
+  providers: [
+    ClassAnalyticsService,
+    AnalyticsQueueService,
+    AnalyticsWorkerService,
+    AnalyticsCronService,
+    SimuladoHttpService,
+    HttpServiceAxiosFactory,
+  ],
 })
 export class ClassAnalyticsModule {}

--- a/src/modules/prepCourse/class/analytics/class-analytics.service.spec.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.service.spec.ts
@@ -4,6 +4,7 @@ import { StatusApplication } from '../../studentCourse/enums/stastusApplication'
 import { ClassAnalyticsService } from './class-analytics.service';
 import { ClassService } from '../class.service';
 import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
+import { AnalyticsQueueService } from './queue/analytics-queue.service';
 
 const ACTIVE_START = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // 30 days ago
 const ACTIVE_END = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days from now
@@ -35,6 +36,7 @@ describe('ClassAnalyticsService', () => {
   let service: ClassAnalyticsService;
   let classService: jest.Mocked<ClassService>;
   let simuladoHttp: jest.Mocked<SimuladoHttpService>;
+  let queue: jest.Mocked<AnalyticsQueueService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -54,12 +56,20 @@ describe('ClassAnalyticsService', () => {
             calculateUserGroupAggregate: jest.fn(),
           },
         },
+        {
+          provide: AnalyticsQueueService,
+          useValue: {
+            enqueue: jest.fn().mockResolvedValue('id-1'),
+            enqueueMany: jest.fn().mockResolvedValue(['id-1']),
+          },
+        },
       ],
     }).compile();
 
     service = module.get(ClassAnalyticsService);
     classService = module.get(ClassService) as jest.Mocked<ClassService>;
     simuladoHttp = module.get(SimuladoHttpService) as jest.Mocked<SimuladoHttpService>;
+    queue = module.get(AnalyticsQueueService) as jest.Mocked<AnalyticsQueueService>;
   });
 
   // ── listMonths ──────────────────────────────────────────────────────────────
@@ -152,15 +162,18 @@ describe('ClassAnalyticsService', () => {
   // ── refresh ─────────────────────────────────────────────────────────────────
 
   describe('refresh', () => {
-    it('with scope=current calls calculateUserGroupAggregate exactly once', async () => {
+    it('with scope=current enqueues exactly one message', async () => {
       classService.findOneById.mockResolvedValue(makeClass());
-      simuladoHttp.calculateUserGroupAggregate.mockResolvedValue({});
 
       const result = await service.refresh('class-1', 'current', 'requester-1');
 
-      expect(simuladoHttp.calculateUserGroupAggregate).toHaveBeenCalledTimes(1);
+      expect(queue.enqueueMany).toHaveBeenCalledTimes(1);
+      const items = queue.enqueueMany.mock.calls[0][0];
+      expect(items).toHaveLength(1);
+      expect(items[0].classId).toBe('class-1');
+      expect(simuladoHttp.calculateUserGroupAggregate).not.toHaveBeenCalled();
       expect(result.enqueued).toHaveLength(1);
-      expect(result.estimatedSeconds).toBe(1);
+      expect(result.estimatedSeconds).toBe(2);
     });
 
     it('throws BadRequestException when class period has ended', async () => {
@@ -175,19 +188,22 @@ describe('ClassAnalyticsService', () => {
         service.refresh('class-1', 'current', 'requester-1'),
       ).rejects.toThrow(BadRequestException);
 
-      expect(simuladoHttp.calculateUserGroupAggregate).not.toHaveBeenCalled();
+      expect(queue.enqueueMany).not.toHaveBeenCalled();
     });
 
-    it('only includes userIds of students with status Enrolled', async () => {
-      classService.findOneById.mockResolvedValue(makeClass());
-      simuladoHttp.calculateUserGroupAggregate.mockResolvedValue({});
+    it('with scope=all enqueues one message per month of the period', async () => {
+      classService.findOneById.mockResolvedValue(
+        makeClass({
+          coursePeriodStartDate: new Date('2026-01-01'),
+          coursePeriodEndDate: new Date('2026-12-31'),
+        }),
+      );
 
-      await service.refresh('class-1', 'current', 'requester-1');
+      await service.refresh('class-1', 'all', 'requester-1');
 
-      const callArgs = simuladoHttp.calculateUserGroupAggregate.mock.calls[0][0];
-      // Only user-1 is Enrolled; user-2 is UnderReview
-      expect(callArgs.userIds).toEqual(['user-1']);
-      expect(callArgs.userIds).not.toContain('user-2');
+      const items = queue.enqueueMany.mock.calls[0][0];
+      expect(items.length).toBeGreaterThanOrEqual(1);
+      expect(items.every((i) => i.classId === 'class-1')).toBe(true);
     });
   });
 });

--- a/src/modules/prepCourse/class/analytics/class-analytics.service.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.service.ts
@@ -1,9 +1,8 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { ClassService } from '../class.service';
 import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
-import { StatusApplication } from '../../studentCourse/enums/stastusApplication';
+import { AnalyticsQueueService } from './queue/analytics-queue.service';
 import {
-  computeMonthWindow,
   isActivePeriod,
   listMonthsInPeriod,
 } from './utils/month-window';
@@ -13,6 +12,7 @@ export class ClassAnalyticsService {
   constructor(
     private readonly classService: ClassService,
     private readonly simuladoHttp: SimuladoHttpService,
+    private readonly queue: AnalyticsQueueService,
   ) {}
 
   async listMonths(classId: string, requesterId: string) {
@@ -88,24 +88,13 @@ export class ClassAnalyticsService {
     const monthsToRefresh =
       scope === 'all' ? allMonths : [allMonths[allMonths.length - 1]];
 
-    const enrolledUserIds = (klass.students ?? [])
-      .filter((s) => s.status === StatusApplication.Enrolled)
-      .map((s) => s.userId);
-
-    for (const month of monthsToRefresh) {
-      const { monthStart, monthEnd } = computeMonthWindow(month, period);
-      await this.simuladoHttp.calculateUserGroupAggregate({
-        groupId: classId,
-        month,
-        monthStart,
-        monthEnd,
-        userIds: enrolledUserIds,
-      });
-    }
+    await this.queue.enqueueMany(
+      monthsToRefresh.map((m) => ({ classId, month: m })),
+    );
 
     return {
       enqueued: monthsToRefresh.map((m) => ({ classId, month: m })),
-      estimatedSeconds: monthsToRefresh.length,
+      estimatedSeconds: monthsToRefresh.length * 2,
     };
   }
 }

--- a/src/modules/prepCourse/class/analytics/crons/analytics-cron.service.spec.ts
+++ b/src/modules/prepCourse/class/analytics/crons/analytics-cron.service.spec.ts
@@ -1,0 +1,60 @@
+import { ClassService } from '../../class.service';
+import { AnalyticsQueueService } from '../queue/analytics-queue.service';
+import { AnalyticsCronService } from './analytics-cron.service';
+
+describe('AnalyticsCronService', () => {
+  let classService: jest.Mocked<ClassService>;
+  let queue: jest.Mocked<AnalyticsQueueService>;
+  let cron: AnalyticsCronService;
+
+  beforeEach(() => {
+    classService = { findAllWithActivePeriod: jest.fn() } as any;
+    queue = { enqueue: jest.fn().mockResolvedValue('id'), enqueueMany: jest.fn() } as any;
+    cron = new AnalyticsCronService(classService, queue);
+  });
+
+  const klass = (id: string, startDate: string, endDate: string) =>
+    ({
+      id,
+      coursePeriod: {
+        startDate: new Date(startDate),
+        endDate: new Date(endDate),
+      },
+    }) as any;
+
+  it('weekly cron enqueues current month for each active class', async () => {
+    classService.findAllWithActivePeriod.mockResolvedValue([
+      klass('c1', '2026-01-01', '2026-12-31'),
+      klass('c2', '2026-01-01', '2026-12-31'),
+    ]);
+
+    await cron.weeklyRefreshCurrentMonth();
+
+    expect(queue.enqueue).toHaveBeenCalledTimes(2);
+    // Both classes get the same current month (last month of period or today)
+    const months = queue.enqueue.mock.calls.map((c) => c[1]);
+    expect(new Set(months).size).toBe(1);
+  });
+
+  it('monthly cron enqueues all months for each active class', async () => {
+    classService.findAllWithActivePeriod.mockResolvedValue([
+      klass('c1', '2026-01-01', '2026-03-31'),
+    ]);
+
+    await cron.monthlyRefreshAllMonths();
+
+    // Period covers Jan, Feb, Mar — 3 months for 1 class
+    expect(queue.enqueue.mock.calls.length).toBeGreaterThanOrEqual(1);
+    const calls = queue.enqueue.mock.calls;
+    expect(calls.every((c) => c[0] === 'c1')).toBe(true);
+  });
+
+  it('skips classes without coursePeriod', async () => {
+    classService.findAllWithActivePeriod.mockResolvedValue([
+      { id: 'c1', coursePeriod: null } as any,
+    ]);
+
+    await cron.weeklyRefreshCurrentMonth();
+    expect(queue.enqueue).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/prepCourse/class/analytics/crons/analytics-cron.service.ts
+++ b/src/modules/prepCourse/class/analytics/crons/analytics-cron.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ClassService } from '../../class.service';
+import { listMonthsInPeriod } from '../utils/month-window';
+import { AnalyticsQueueService } from '../queue/analytics-queue.service';
+
+@Injectable()
+export class AnalyticsCronService {
+  private readonly logger = new Logger(AnalyticsCronService.name);
+
+  constructor(
+    private readonly classService: ClassService,
+    private readonly queue: AnalyticsQueueService,
+  ) {}
+
+  @Cron('0 3 * * 1')
+  async weeklyRefreshCurrentMonth() {
+    const activeClasses = await this.classService.findAllWithActivePeriod();
+    let count = 0;
+    for (const klass of activeClasses) {
+      if (!klass.coursePeriod) continue;
+      const months = listMonthsInPeriod({
+        startDate: new Date(klass.coursePeriod.startDate),
+        endDate: new Date(klass.coursePeriod.endDate),
+      });
+      const currentMonth = months[months.length - 1];
+      if (!currentMonth) continue;
+      await this.queue.enqueue(klass.id, currentMonth);
+      count++;
+    }
+    this.logger.log(`Weekly cron enqueued ${count} jobs (current month only)`);
+  }
+
+  @Cron('0 3 1 * *')
+  async monthlyRefreshAllMonths() {
+    const activeClasses = await this.classService.findAllWithActivePeriod();
+    let count = 0;
+    for (const klass of activeClasses) {
+      if (!klass.coursePeriod) continue;
+      const months = listMonthsInPeriod({
+        startDate: new Date(klass.coursePeriod.startDate),
+        endDate: new Date(klass.coursePeriod.endDate),
+      });
+      for (const month of months) {
+        await this.queue.enqueue(klass.id, month);
+        count++;
+      }
+    }
+    this.logger.log(
+      `Monthly cron enqueued ${count} jobs (all months of active classes)`,
+    );
+  }
+}

--- a/src/modules/prepCourse/class/analytics/queue/analytics-queue.service.spec.ts
+++ b/src/modules/prepCourse/class/analytics/queue/analytics-queue.service.spec.ts
@@ -1,0 +1,40 @@
+import { QueueProducer } from '../../../../../shared/modules/queue/queue.producer';
+import {
+  ANALYTICS_STREAM,
+  AnalyticsQueueService,
+} from './analytics-queue.service';
+
+describe('AnalyticsQueueService', () => {
+  let producer: jest.Mocked<QueueProducer>;
+  let service: AnalyticsQueueService;
+
+  beforeEach(() => {
+    producer = { publish: jest.fn().mockResolvedValue('id-1') } as any;
+    service = new AnalyticsQueueService(producer);
+  });
+
+  it('enqueue publishes to ANALYTICS_STREAM with classId+month', async () => {
+    const id = await service.enqueue('class-1', '2026-05');
+    expect(id).toBe('id-1');
+    expect(producer.publish).toHaveBeenCalledWith(ANALYTICS_STREAM, {
+      classId: 'class-1',
+      month: '2026-05',
+    });
+  });
+
+  it('enqueueMany publishes once per item', async () => {
+    producer.publish
+      .mockResolvedValueOnce('a')
+      .mockResolvedValueOnce('b')
+      .mockResolvedValueOnce('c');
+
+    const ids = await service.enqueueMany([
+      { classId: 'c1', month: '2026-01' },
+      { classId: 'c1', month: '2026-02' },
+      { classId: 'c2', month: '2026-03' },
+    ]);
+
+    expect(ids).toEqual(['a', 'b', 'c']);
+    expect(producer.publish).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/modules/prepCourse/class/analytics/queue/analytics-queue.service.ts
+++ b/src/modules/prepCourse/class/analytics/queue/analytics-queue.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { QueueProducer } from '../../../../../shared/modules/queue/queue.producer';
+
+export const ANALYTICS_STREAM = 'stream:vcnafacul:analytics-recalc';
+
+@Injectable()
+export class AnalyticsQueueService {
+  constructor(private readonly producer: QueueProducer) {}
+
+  async enqueue(classId: string, month: string): Promise<string> {
+    return this.producer.publish(ANALYTICS_STREAM, { classId, month });
+  }
+
+  async enqueueMany(
+    items: Array<{ classId: string; month: string }>,
+  ): Promise<string[]> {
+    return Promise.all(items.map((i) => this.enqueue(i.classId, i.month)));
+  }
+}

--- a/src/modules/prepCourse/class/analytics/queue/analytics-worker.service.spec.ts
+++ b/src/modules/prepCourse/class/analytics/queue/analytics-worker.service.spec.ts
@@ -1,0 +1,82 @@
+import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
+import { ClassService } from '../../class.service';
+import { QueueConsumer } from '../../../../../shared/modules/queue/queue.consumer';
+import { AnalyticsWorkerService } from './analytics-worker.service';
+import { StatusApplication } from '../../../studentCourse/enums/stastusApplication';
+
+describe('AnalyticsWorkerService', () => {
+  let consumer: jest.Mocked<QueueConsumer>;
+  let classService: jest.Mocked<ClassService>;
+  let simuladoHttp: jest.Mocked<SimuladoHttpService>;
+  let worker: AnalyticsWorkerService;
+
+  beforeEach(() => {
+    consumer = { register: jest.fn() } as any;
+    classService = { findOneByIdForAnalytics: jest.fn() } as any;
+    simuladoHttp = { calculateUserGroupAggregate: jest.fn() } as any;
+    worker = new AnalyticsWorkerService(consumer, classService, simuladoHttp);
+  });
+
+  it('registers consumer on init', () => {
+    worker.onModuleInit();
+    expect(consumer.register).toHaveBeenCalledWith(
+      'stream:vcnafacul:analytics-recalc',
+      'api-vcnafacul-analytics',
+      'worker-1',
+      expect.any(Function),
+    );
+  });
+
+  it('calls calculate with enrolled userIds only', async () => {
+    classService.findOneByIdForAnalytics.mockResolvedValue({
+      id: 'class-1',
+      coursePeriod: {
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-12-31'),
+      },
+      students: [
+        { userId: 'u1', applicationStatus: StatusApplication.Enrolled },
+        { userId: 'u2', applicationStatus: StatusApplication.Rejected },
+        { userId: 'u3', applicationStatus: StatusApplication.Enrolled },
+      ],
+    } as any);
+    simuladoHttp.calculateUserGroupAggregate.mockResolvedValue({} as any);
+
+    await worker.handle('msg-1', { classId: 'class-1', month: '2026-05' });
+
+    expect(simuladoHttp.calculateUserGroupAggregate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        groupId: 'class-1',
+        month: '2026-05',
+        userIds: ['u1', 'u3'],
+      }),
+    );
+  });
+
+  it('skips when class not found', async () => {
+    classService.findOneByIdForAnalytics.mockResolvedValue(null);
+    await worker.handle('m', { classId: 'missing', month: '2026-05' });
+    expect(simuladoHttp.calculateUserGroupAggregate).not.toHaveBeenCalled();
+  });
+
+  it('skips when missing fields', async () => {
+    await worker.handle('m', { classId: 'x' });
+    expect(classService.findOneByIdForAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('propagates error so Valkey can retry', async () => {
+    classService.findOneByIdForAnalytics.mockResolvedValue({
+      id: 'class-1',
+      coursePeriod: {
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-12-31'),
+      },
+      students: [],
+    } as any);
+    simuladoHttp.calculateUserGroupAggregate.mockRejectedValue(new Error('boom'));
+
+    await expect(
+      worker.handle('m', { classId: 'class-1', month: '2026-05' }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/src/modules/prepCourse/class/analytics/queue/analytics-worker.service.ts
+++ b/src/modules/prepCourse/class/analytics/queue/analytics-worker.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
+import { StatusApplication } from '../../../studentCourse/enums/stastusApplication';
+import { ClassService } from '../../class.service';
+import { computeMonthWindow } from '../utils/month-window';
+import { QueueConsumer } from '../../../../../shared/modules/queue/queue.consumer';
+import { ANALYTICS_STREAM } from './analytics-queue.service';
+
+@Injectable()
+export class AnalyticsWorkerService implements OnModuleInit {
+  private readonly logger = new Logger(AnalyticsWorkerService.name);
+
+  constructor(
+    private readonly consumer: QueueConsumer,
+    private readonly classService: ClassService,
+    private readonly simuladoHttp: SimuladoHttpService,
+  ) {}
+
+  onModuleInit() {
+    this.consumer.register(
+      ANALYTICS_STREAM,
+      'api-vcnafacul-analytics',
+      'worker-1',
+      (id, fields) => this.handle(id, fields),
+    );
+  }
+
+  async handle(_id: string, fields: Record<string, string>) {
+    const { classId, month } = fields;
+    if (!classId || !month) {
+      this.logger.warn(`Skipping message with missing fields: ${JSON.stringify(fields)}`);
+      return;
+    }
+
+    const klass = await this.classService.findOneByIdForAnalytics(classId);
+    if (!klass?.coursePeriod) {
+      this.logger.warn(`Class ${classId} not found or has no coursePeriod; skipping ${month}`);
+      return;
+    }
+
+    const period = {
+      startDate: new Date(klass.coursePeriod.startDate),
+      endDate: new Date(klass.coursePeriod.endDate),
+    };
+    const { monthStart, monthEnd } = computeMonthWindow(month, period);
+
+    const userIds = (klass.students ?? [])
+      .filter((s) => s.applicationStatus === StatusApplication.Enrolled)
+      .map((s) => s.userId);
+
+    try {
+      await this.simuladoHttp.calculateUserGroupAggregate({
+        groupId: classId,
+        month,
+        monthStart,
+        monthEnd,
+        userIds,
+      });
+      this.logger.log(`Recalculated ${classId} / ${month}`);
+    } catch (err) {
+      this.logger.error(`Failed to recalc ${classId} / ${month}`, err as Error);
+      throw err;
+    }
+  }
+}

--- a/src/modules/prepCourse/class/class.repository.ts
+++ b/src/modules/prepCourse/class/class.repository.ts
@@ -122,6 +122,32 @@ export class ClassRepository extends BaseRepository<Class> {
       .getOne();
   }
 
+  async findOneByIdForAnalytics(id: string): Promise<Class | null> {
+    return this.repository
+      .createQueryBuilder('entity')
+      .leftJoin('entity.students', 'student_course')
+      .addSelect([
+        'student_course.id',
+        'student_course.userId',
+        'student_course.applicationStatus',
+      ])
+      .leftJoinAndSelect('entity.coursePeriod', 'course_period')
+      .where('entity.id = :id', { id })
+      .andWhere('entity.deletedAt IS NULL')
+      .getOne();
+  }
+
+  async findAllWithActivePeriod(): Promise<Class[]> {
+    const today = new Date();
+    return this.repository
+      .createQueryBuilder('entity')
+      .innerJoinAndSelect('entity.coursePeriod', 'course_period')
+      .where('entity.deletedAt IS NULL')
+      .andWhere('course_period.startDate <= :today', { today })
+      .andWhere('course_period.endDate >= :today', { today })
+      .getMany();
+  }
+
   async findOneByIdWithPartner(id: string): Promise<Class> {
     return this.repository
       .createQueryBuilder('entity')

--- a/src/modules/prepCourse/class/class.service.ts
+++ b/src/modules/prepCourse/class/class.service.ts
@@ -251,6 +251,14 @@ export class ClassService extends BaseService<Class> {
     };
   }
 
+  async findOneByIdForAnalytics(id: string): Promise<Class | null> {
+    return this.repository.findOneByIdForAnalytics(id);
+  }
+
+  async findAllWithActivePeriod(): Promise<Class[]> {
+    return this.repository.findAllWithActivePeriod();
+  }
+
   async findOneByIdToAttendanceRecord(
     id: string,
   ): Promise<GetClassByIdAttendanceDtoOutput> {

--- a/src/shared/enum/queue-driver.enum.ts
+++ b/src/shared/enum/queue-driver.enum.ts
@@ -1,0 +1,4 @@
+export enum QueueDriver {
+  Redis = 'redis',
+  Memory = 'memory',
+}

--- a/src/shared/modules/env/env.ts
+++ b/src/shared/modules/env/env.ts
@@ -78,6 +78,9 @@ export const envSchema = z.object({
   REDIS_PORT: z.coerce.number().default(6379),
   REDIS_HOST: z.string().default('localhost'),
 
+  //Queue
+  QUEUE_DRIVER: z.enum(['redis', 'memory']).default('memory'),
+
   // Form Service
   ADMIN_FORM_SECRET: z.string().default('dev-secret'),
 

--- a/src/shared/modules/queue/in-memory/in-memory-queue.consumer.ts
+++ b/src/shared/modules/queue/in-memory/in-memory-queue.consumer.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { QueueConsumer } from '../queue.consumer';
+import { MessageHandler } from '../queue.types';
+import { memoryBus } from './memory-bus';
+
+@Injectable()
+export class InMemoryQueueConsumer extends QueueConsumer {
+  register(
+    stream: string,
+    _group: string,
+    _consumer: string,
+    handler: MessageHandler,
+  ) {
+    memoryBus.on(stream, (id: string, fields: Record<string, string>) => {
+      handler(id, fields).catch((err) =>
+        console.error(`[InMemoryQueue] error on ${stream}:`, err),
+      );
+    });
+  }
+}

--- a/src/shared/modules/queue/in-memory/in-memory-queue.producer.ts
+++ b/src/shared/modules/queue/in-memory/in-memory-queue.producer.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { QueueProducer } from '../queue.producer';
+import { memoryBus } from './memory-bus';
+
+@Injectable()
+export class InMemoryQueueProducer extends QueueProducer {
+  async publish(
+    stream: string,
+    payload: Record<string, string>,
+  ): Promise<string> {
+    const id = `${Date.now()}-0`;
+    setImmediate(() => memoryBus.emit(stream, id, payload));
+    return id;
+  }
+}

--- a/src/shared/modules/queue/in-memory/in-memory-queue.spec.ts
+++ b/src/shared/modules/queue/in-memory/in-memory-queue.spec.ts
@@ -1,0 +1,38 @@
+import { InMemoryQueueConsumer } from './in-memory-queue.consumer';
+import { InMemoryQueueProducer } from './in-memory-queue.producer';
+import { memoryBus } from './memory-bus';
+
+describe('InMemory Queue', () => {
+  let producer: InMemoryQueueProducer;
+  let consumer: InMemoryQueueConsumer;
+
+  beforeEach(() => {
+    memoryBus.removeAllListeners();
+    producer = new InMemoryQueueProducer();
+    consumer = new InMemoryQueueConsumer();
+  });
+
+  it('delivers message to registered handler', async () => {
+    const received: Record<string, string>[] = [];
+
+    consumer.register('stream:test', 'g', 'c', async (_id, fields) => {
+      received.push(fields);
+    });
+
+    await producer.publish('stream:test', { foo: 'bar' });
+
+    await new Promise((r) => setImmediate(r));
+    expect(received).toHaveLength(1);
+    expect(received[0].foo).toBe('bar');
+  });
+
+  it('does not deliver to wrong stream', async () => {
+    const received: Record<string, string>[] = [];
+    consumer.register('stream:other', 'g', 'c', async (_id, fields) => {
+      received.push(fields);
+    });
+    await producer.publish('stream:test', { foo: 'bar' });
+    await new Promise((r) => setImmediate(r));
+    expect(received).toHaveLength(0);
+  });
+});

--- a/src/shared/modules/queue/in-memory/memory-bus.ts
+++ b/src/shared/modules/queue/in-memory/memory-bus.ts
@@ -1,0 +1,4 @@
+import { EventEmitter } from 'events';
+
+export const memoryBus = new EventEmitter();
+memoryBus.setMaxListeners(50);

--- a/src/shared/modules/queue/queue.consumer.ts
+++ b/src/shared/modules/queue/queue.consumer.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { MessageHandler } from './queue.types';
+
+@Injectable()
+export abstract class QueueConsumer {
+  abstract register(
+    stream: string,
+    group: string,
+    consumer: string,
+    handler: MessageHandler,
+  ): void;
+}

--- a/src/shared/modules/queue/queue.module.ts
+++ b/src/shared/modules/queue/queue.module.ts
@@ -1,0 +1,48 @@
+import { Global, Module } from '@nestjs/common';
+import Redis from 'ioredis';
+import { QueueDriver } from '../../enum/queue-driver.enum';
+import { EnvModule } from '../env/env.module';
+import { EnvService } from '../env/env.service';
+import { InMemoryQueueConsumer } from './in-memory/in-memory-queue.consumer';
+import { InMemoryQueueProducer } from './in-memory/in-memory-queue.producer';
+import { QueueConsumer } from './queue.consumer';
+import { QueueProducer } from './queue.producer';
+import { ValkeyQueueConsumer } from './valkey/valkey-queue.consumer';
+import { ValkeyQueueProducer } from './valkey/valkey-queue.producer';
+
+@Global()
+@Module({
+  imports: [EnvModule],
+  providers: [
+    {
+      provide: 'QUEUE_REDIS_CLIENT',
+      inject: [EnvService],
+      useFactory: (env: EnvService) => {
+        if (env.get('QUEUE_DRIVER') !== QueueDriver.Redis) return null;
+        return new Redis({
+          host: env.get('REDIS_HOST'),
+          port: env.get('REDIS_PORT'),
+          lazyConnect: true,
+        });
+      },
+    },
+    {
+      provide: QueueProducer,
+      inject: [EnvService, 'QUEUE_REDIS_CLIENT'],
+      useFactory: (env: EnvService, redis: Redis | null) =>
+        env.get('QUEUE_DRIVER') === QueueDriver.Redis
+          ? new ValkeyQueueProducer(redis as Redis)
+          : new InMemoryQueueProducer(),
+    },
+    {
+      provide: QueueConsumer,
+      inject: [EnvService, 'QUEUE_REDIS_CLIENT'],
+      useFactory: (env: EnvService, redis: Redis | null) =>
+        env.get('QUEUE_DRIVER') === QueueDriver.Redis
+          ? new ValkeyQueueConsumer(redis as Redis)
+          : new InMemoryQueueConsumer(),
+    },
+  ],
+  exports: [QueueProducer, QueueConsumer],
+})
+export class QueueModule {}

--- a/src/shared/modules/queue/queue.producer.ts
+++ b/src/shared/modules/queue/queue.producer.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export abstract class QueueProducer {
+  abstract publish(
+    stream: string,
+    payload: Record<string, string>,
+  ): Promise<string>;
+}

--- a/src/shared/modules/queue/queue.types.ts
+++ b/src/shared/modules/queue/queue.types.ts
@@ -1,0 +1,4 @@
+export type MessageHandler = (
+  id: string,
+  fields: Record<string, string>,
+) => Promise<void>;

--- a/src/shared/modules/queue/valkey/valkey-queue.consumer.ts
+++ b/src/shared/modules/queue/valkey/valkey-queue.consumer.ts
@@ -1,0 +1,152 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import Redis from 'ioredis';
+import { QueueConsumer } from '../queue.consumer';
+import { MessageHandler } from '../queue.types';
+
+type Registration = {
+  stream: string;
+  group: string;
+  consumer: string;
+  handler: MessageHandler;
+};
+
+@Injectable()
+export class ValkeyQueueConsumer
+  extends QueueConsumer
+  implements OnModuleInit, OnModuleDestroy
+{
+  private readonly logger = new Logger(ValkeyQueueConsumer.name);
+  private running = false;
+  private readonly registrations: Registration[] = [];
+
+  constructor(@Inject('QUEUE_REDIS_CLIENT') private readonly redis: Redis) {
+    super();
+  }
+
+  register(
+    stream: string,
+    group: string,
+    consumer: string,
+    handler: MessageHandler,
+  ) {
+    this.registrations.push({ stream, group, consumer, handler });
+  }
+
+  async onModuleInit() {
+    for (const { stream, group } of this.registrations) {
+      await this.ensureGroup(stream, group);
+    }
+    this.running = true;
+    this.poll().catch((err) => this.logger.error('Polling error:', err));
+  }
+
+  onModuleDestroy() {
+    this.running = false;
+  }
+
+  private async ensureGroup(stream: string, group: string) {
+    try {
+      await this.redis.xgroup('CREATE', stream, group, '$', 'MKSTREAM');
+    } catch (err: any) {
+      if (!err.message.includes('BUSYGROUP')) throw err;
+    }
+  }
+
+  private async poll() {
+    while (this.running) {
+      for (const reg of this.registrations) {
+        await this.readAndProcess(reg);
+        await this.reclaimStale(reg);
+      }
+    }
+  }
+
+  private async readAndProcess({
+    stream,
+    group,
+    consumer,
+    handler,
+  }: Registration) {
+    const results = (await this.redis.xreadgroup(
+      'GROUP',
+      group,
+      consumer,
+      'COUNT',
+      '10',
+      'BLOCK',
+      '2000',
+      'STREAMS',
+      stream,
+      '>',
+    )) as [string, [string, string[]][]][] | null;
+
+    if (!results) return;
+
+    for (const [, messages] of results) {
+      for (const [id, rawFields] of messages) {
+        const fields = this.parseFields(rawFields);
+        try {
+          await handler(id, fields);
+          await this.redis.xack(stream, group, id);
+          await this.redis.xdel(stream, id);
+        } catch (err) {
+          this.logger.error(`Failed processing ${id} from ${stream}:`, err);
+        }
+      }
+    }
+  }
+
+  private async reclaimStale({
+    stream,
+    group,
+    consumer,
+    handler,
+  }: Registration) {
+    if (!this.running) return;
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    try {
+      const result = await this.redis.xautoclaim(
+        stream,
+        group,
+        consumer,
+        '60000',
+        '0-0',
+        'COUNT',
+        '5',
+      );
+
+      if (!result) return;
+
+      const [, messages] = result as [string, [string, string[]][], string[]];
+
+      for (const [id, rawFields] of messages) {
+        const fields = this.parseFields(rawFields);
+        try {
+          await handler(id, fields);
+          await this.redis.xack(stream, group, id);
+          await this.redis.xdel(stream, id);
+        } catch (err) {
+          this.logger.error(`Failed reclaiming ${id} from ${stream}:`, err);
+        }
+      }
+    } catch (err) {
+      this.logger.error(`Reclaim process error for ${stream}:`, err);
+    }
+  }
+
+  private parseFields(raw: string[]): Record<string, string> {
+    const result: Record<string, string> = {};
+    for (let i = 0; i < raw.length; i += 2) {
+      result[raw[i]] = raw[i + 1];
+    }
+    return result;
+  }
+}

--- a/src/shared/modules/queue/valkey/valkey-queue.producer.spec.ts
+++ b/src/shared/modules/queue/valkey/valkey-queue.producer.spec.ts
@@ -1,0 +1,43 @@
+import { ValkeyQueueProducer } from './valkey-queue.producer';
+
+describe('ValkeyQueueProducer', () => {
+  it('calls xadd with stream and payload', async () => {
+    const redisMock = { xadd: jest.fn().mockResolvedValue('1717000000001-0') };
+    const producer = new ValkeyQueueProducer(redisMock as any);
+
+    const id = await producer.publish('stream:test', { foo: 'bar' });
+
+    expect(id).toBe('1717000000001-0');
+    expect(redisMock.xadd).toHaveBeenCalledWith(
+      'stream:test',
+      'MAXLEN',
+      '~',
+      '10000',
+      '*',
+      'foo',
+      'bar',
+    );
+  });
+
+  it('flattens multiple payload entries', async () => {
+    const redisMock = { xadd: jest.fn().mockResolvedValue('1717000000002-0') };
+    const producer = new ValkeyQueueProducer(redisMock as any);
+
+    await producer.publish('stream:analytics', {
+      classId: 'class-1',
+      month: '2026-05',
+    });
+
+    expect(redisMock.xadd).toHaveBeenCalledWith(
+      'stream:analytics',
+      'MAXLEN',
+      '~',
+      '10000',
+      '*',
+      'classId',
+      'class-1',
+      'month',
+      '2026-05',
+    );
+  });
+});

--- a/src/shared/modules/queue/valkey/valkey-queue.producer.ts
+++ b/src/shared/modules/queue/valkey/valkey-queue.producer.ts
@@ -1,0 +1,28 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import Redis from 'ioredis';
+import { QueueProducer } from '../queue.producer';
+
+@Injectable()
+export class ValkeyQueueProducer extends QueueProducer {
+  private readonly logger = new Logger(ValkeyQueueProducer.name);
+
+  constructor(@Inject('QUEUE_REDIS_CLIENT') private readonly redis: Redis) {
+    super();
+  }
+
+  async publish(
+    stream: string,
+    payload: Record<string, string>,
+  ): Promise<string> {
+    const id = await this.redis.xadd(
+      stream,
+      'MAXLEN',
+      '~',
+      '10000',
+      '*',
+      ...Object.entries(payload).flat(),
+    );
+    this.logger.debug(`Published ${id} → ${stream}`);
+    return id as string;
+  }
+}

--- a/test/class-analytics.e2e-spec.ts
+++ b/test/class-analytics.e2e-spec.ts
@@ -317,9 +317,9 @@ describe('ClassAnalytics (e2e)', () => {
       .expect(404);
   }, 30000);
 
-  // ─── Cenário 4: 202 refresh current ───────────────────────────────────────
+  // ─── Cenário 4: 202 refresh current (enfileiramento) ──────────────────────
 
-  it('should return 202 and call calculateUserGroupAggregate once for current month refresh', async () => {
+  it('should return 202 and enqueue exactly one job for current month refresh', async () => {
     const { user } = await createPartnerWithAnalyticsRole();
     const token = await jwtService.signAsync(
       { user: { id: user.id } },
@@ -328,23 +328,20 @@ describe('ClassAnalytics (e2e)', () => {
 
     const { classId } = await createClassWithActivePeriod(user.id);
 
-    simuladoHttpMock.calculateUserGroupAggregate.mockResolvedValue({});
-
     const response = await request(app.getHttpServer())
       .post(`/class/${classId}/analytics/simulado/refresh`)
       .set({ Authorization: `Bearer ${token}` })
       .expect(202);
 
-    expect(simuladoHttpMock.calculateUserGroupAggregate).toHaveBeenCalledTimes(
-      1,
-    );
     expect(response.body.enqueued).toHaveLength(1);
     expect(response.body.enqueued[0].classId).toBe(classId);
+    expect(response.body.enqueued[0].month).toMatch(/^\d{4}-\d{2}$/);
+    expect(response.body.estimatedSeconds).toBe(2);
   }, 30000);
 
-  // ─── Cenário 5: 202 refresh all ───────────────────────────────────────────
+  // ─── Cenário 5: 202 refresh all (enfileiramento múltiplo) ─────────────────
 
-  it('should return 202 and call calculateUserGroupAggregate N times for refresh?all=true', async () => {
+  it('should return 202 and enqueue N jobs for refresh?all=true', async () => {
     const { user } = await createPartnerWithAnalyticsRole();
     const token = await jwtService.signAsync(
       { user: { id: user.id } },
@@ -352,11 +349,7 @@ describe('ClassAnalytics (e2e)', () => {
     );
 
     // Period starts 3 months ago → at least 3 months available
-    const { classId, coursePeriod } = await createClassWithActivePeriod(
-      user.id,
-    );
-
-    simuladoHttpMock.calculateUserGroupAggregate.mockResolvedValue({});
+    const { classId } = await createClassWithActivePeriod(user.id);
 
     const response = await request(app.getHttpServer())
       .post(`/class/${classId}/analytics/simulado/refresh?all=true`)
@@ -365,9 +358,7 @@ describe('ClassAnalytics (e2e)', () => {
 
     const expectedMonths = response.body.enqueued.length;
     expect(expectedMonths).toBeGreaterThan(1);
-    expect(simuladoHttpMock.calculateUserGroupAggregate).toHaveBeenCalledTimes(
-      expectedMonths,
-    );
+    expect(response.body.estimatedSeconds).toBe(expectedMonths * 2);
     response.body.enqueued.forEach((entry: { classId: string; month: string }) => {
       expect(entry.classId).toBe(classId);
       expect(entry.month).toMatch(/^\d{4}-\d{2}$/);


### PR DESCRIPTION
## Summary
Fase D do turma-analytics-simulado — substitui chamadas síncronas ao ms-simulado por uma fila durável + workers + crons.

- **QueueModule global** com factory Redis|InMemory (env `QUEUE_DRIVER`, default `memory` para dev/homol; `redis` em prod)
- **Valkey adapter**: producer via `XADD` + consumer group com `XREADGROUP`, `XACK`, `XAUTOCLAIM` para retry/reclaim
- **InMemory adapter**: `EventEmitter` para rodar sem Redis em dev
- **AnalyticsQueueService**: `enqueue(classId, month)` / `enqueueMany(items)` publicando no stream `stream:vcnafacul:analytics-recalc`
- **AnalyticsWorkerService**: consome o stream, recarrega a turma com `findOneByIdForAnalytics` (filtra alunos `Enrolled`), e chama `simuladoHttp.calculateUserGroupAggregate` — erros propagam para retry do Valkey
- **AnalyticsCronService**:
  - Semanal (`0 3 * * 1`): mês atual de cada turma ativa
  - Mensal (`0 3 1 * *`): todos os meses do período de cada turma ativa
- **refresh()** agora enfileira em vez de chamar simulado direto; retorna `202` com `{ enqueued[], estimatedSeconds }`
- **ClassRepository**: novos `findOneByIdForAnalytics` (otimizado para worker) e `findAllWithActivePeriod` (filtra por `coursePeriod` ativo, soft-delete-aware)

## Test Plan
- [x] `npm run build` limpo
- [x] 431 unit tests passando (incluindo specs novos: queue, valkey-producer, in-memory, worker, cron, analytics-service)
- [x] E2E `class-analytics.e2e-spec.ts` — 7/7 passando (contrato `/refresh` validado com fila in-memory; verifica DI em runtime — lição da Fase B)
- [ ] Smoke manual em homol: ativar `QUEUE_DRIVER=redis` e validar publicação no Valkey

## Notas
- Os testes E2E de `/refresh` foram ajustados: antes asseguravam que `calculateUserGroupAggregate` fosse chamado N vezes; agora asseguram o contrato da API (status 202 + shape do `enqueued[]` + `estimatedSeconds`), já que a chamada ao ms-simulado é assíncrona no worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)