### PR TITLE
feat(class-essay-analytics): Fase A — backend síncrono de analytics de redações por turma

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -23,6 +23,7 @@ import { PeriodJustificationModule } from './modules/prepCourse/attendance/perio
 import { StudentAttendanceModule } from './modules/prepCourse/attendance/studentAttendance/student-attendance.module';
 import { ClassModule } from './modules/prepCourse/class/class.module';
 import { ClassAnalyticsModule } from './modules/prepCourse/class/analytics/class-analytics.module';
+import { ClassEssayAnalyticsModule } from './modules/prepCourse/class/essay-analytics/class-essay-analytics.module';
 import { CollaboratorModule } from './modules/prepCourse/collaborator/collaborator.module';
 import { CoursePeriodModule } from './modules/prepCourse/coursePeriod/course-period.module';
 import { InscriptionCourseModule } from './modules/prepCourse/InscriptionCourse/inscription-course.module';
@@ -108,6 +109,7 @@ const throttlerProvider: Provider = isTestEnv
     SimuladoModule,
     ClassModule,
     ClassAnalyticsModule,
+    ClassEssayAnalyticsModule,
     AttendanceRecordModule,
     StudentAttendanceModule,
     AbsenceJustificationModule,

--- a/src/db/migrations/1779120574243-ClassEssaySnapshots.ts
+++ b/src/db/migrations/1779120574243-ClassEssaySnapshots.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ClassEssaySnapshots1779120574243 implements MigrationInterface {
+  name = 'ClassEssaySnapshots1779120574243';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE \`class_essay_snapshots\` (\`id\` varchar(36) NOT NULL, \`created_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, \`updated_at\` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, \`deleted_at\` timestamp NULL, \`class_id\` varchar(36) NOT NULL, \`month\` varchar(7) NOT NULL, \`month_start\` timestamp NOT NULL, \`month_end\` timestamp NOT NULL, \`user_ids\` json NOT NULL, \`payload\` json NOT NULL, \`generated_at\` timestamp NOT NULL, \`source_essay_count\` int NOT NULL, UNIQUE INDEX \`IDX_de1016d45c9f3aab5c0cbfcffd\` (\`class_id\`, \`month\`), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`class_essay_snapshots\` ADD CONSTRAINT \`FK_edc029c33761080762d8c479db5\` FOREIGN KEY (\`class_id\`) REFERENCES \`classes\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`class_essay_snapshots\` DROP FOREIGN KEY \`FK_edc029c33761080762d8c479db5\``,
+    );
+    await queryRunner.query(
+      `DROP INDEX \`IDX_de1016d45c9f3aab5c0cbfcffd\` ON \`class_essay_snapshots\``,
+    );
+    await queryRunner.query(`DROP TABLE \`class_essay_snapshots\``);
+  }
+}

--- a/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.controller.ts
+++ b/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  Req,
+  SetMetadata,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { Permissions } from 'src/modules/role/role.entity';
+import { User } from 'src/modules/user/user.entity';
+import { PermissionsGuard } from 'src/shared/guards/permission.guard';
+import { ClassEssayAnalyticsService } from './class-essay-analytics.service';
+import { EssayMonthDtoOutput } from './dtos/essay-month.dto.output';
+import { ListEssayMonthsDtoOutput } from './dtos/list-essay-months.dto.output';
+import { RefreshEssayDtoOutput } from './dtos/refresh-essay.dto.output';
+
+@ApiTags('Class Essay Analytics')
+@Controller('class/:id/analytics/redacao')
+export class ClassEssayAnalyticsController {
+  constructor(private readonly service: ClassEssayAnalyticsService) {}
+
+  @Get()
+  @ApiBearerAuth()
+  @UseGuards(PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.visualizarTurmas)
+  @ApiResponse({ status: 200, type: ListEssayMonthsDtoOutput })
+  async listMonths(@Param('id') id: string, @Req() req: Request) {
+    return this.service.listMonths(id, (req.user as User).id);
+  }
+
+  @Get(':month')
+  @ApiBearerAuth()
+  @UseGuards(PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.visualizarTurmas)
+  @ApiResponse({ status: 200, type: EssayMonthDtoOutput })
+  @ApiResponse({ status: 404 })
+  async getByMonth(
+    @Param('id') id: string,
+    @Param('month') month: string,
+    @Req() req: Request,
+  ) {
+    return this.service.getByMonth(id, month, (req.user as User).id);
+  }
+
+  @Post('refresh')
+  @HttpCode(202)
+  @ApiBearerAuth()
+  @UseGuards(PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.gerenciarTurmas)
+  @ApiResponse({ status: 202, type: RefreshEssayDtoOutput })
+  async refresh(
+    @Param('id') id: string,
+    @Query('all') all: string,
+    @Req() req: Request,
+  ) {
+    const scope = all === 'true' ? 'all' : 'current';
+    return this.service.refresh(id, scope, (req.user as User).id);
+  }
+}

--- a/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.module.ts
+++ b/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { UserModule } from 'src/modules/user/user.module';
+import { EnvModule } from 'src/shared/modules/env/env.module';
 import { ClassModule } from '../class.module';
 import { ClassEssayAnalyticsController } from './class-essay-analytics.controller';
 import { ClassEssayAnalyticsRepository } from './class-essay-analytics.repository';
@@ -7,7 +9,12 @@ import { ClassEssayAnalyticsService } from './class-essay-analytics.service';
 import { ClassEssaySnapshot } from './class-essay-snapshot.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ClassEssaySnapshot]), ClassModule],
+  imports: [
+    TypeOrmModule.forFeature([ClassEssaySnapshot]),
+    ClassModule,
+    UserModule,
+    EnvModule,
+  ],
   controllers: [ClassEssayAnalyticsController],
   providers: [ClassEssayAnalyticsService, ClassEssayAnalyticsRepository],
   exports: [ClassEssayAnalyticsService],

--- a/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.module.ts
+++ b/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ClassModule } from '../class.module';
+import { ClassEssayAnalyticsController } from './class-essay-analytics.controller';
+import { ClassEssayAnalyticsRepository } from './class-essay-analytics.repository';
+import { ClassEssayAnalyticsService } from './class-essay-analytics.service';
+import { ClassEssaySnapshot } from './class-essay-snapshot.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ClassEssaySnapshot]), ClassModule],
+  controllers: [ClassEssayAnalyticsController],
+  providers: [ClassEssayAnalyticsService, ClassEssayAnalyticsRepository],
+  exports: [ClassEssayAnalyticsService],
+})
+export class ClassEssayAnalyticsModule {}

--- a/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.repository.ts
+++ b/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.repository.ts
@@ -1,0 +1,181 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { StatusApplication } from '../../studentCourse/enums/stastusApplication';
+import {
+  ClassEssayPayload,
+  ClassEssaySnapshot,
+} from './class-essay-snapshot.entity';
+
+interface AggregateMonthInput {
+  classId: string;
+  monthStart: Date;
+  monthEnd: Date;
+}
+
+@Injectable()
+export class ClassEssayAnalyticsRepository {
+  constructor(
+    @InjectRepository(ClassEssaySnapshot)
+    private readonly snapRepo: Repository<ClassEssaySnapshot>,
+    @InjectDataSource() private readonly dataSource: DataSource,
+  ) {}
+
+  findOneByMonth(classId: string, month: string) {
+    return this.snapRepo.findOne({ where: { classId, month } });
+  }
+
+  listByClass(classId: string) {
+    return this.snapRepo.find({
+      where: { classId },
+      order: { month: 'DESC' },
+    });
+  }
+
+  async upsert(doc: Partial<ClassEssaySnapshot>) {
+    const existing = await this.snapRepo.findOne({
+      where: { classId: doc.classId, month: doc.month },
+    });
+    if (existing) {
+      Object.assign(existing, doc);
+      return this.snapRepo.save(existing);
+    }
+    return this.snapRepo.save(this.snapRepo.create(doc));
+  }
+
+  async aggregateMonth({
+    classId,
+    monthStart,
+    monthEnd,
+  }: AggregateMonthInput): Promise<ClassEssayPayload> {
+    // 1) Buscar linhas (essay + review humana mais recente) para alunos Enrolled da turma
+    const rows: Array<{
+      userId: string;
+      essayId: string;
+      totalScore: number | string;
+      c1: number | string;
+      c2: number | string;
+      c3: number | string;
+      c4: number | string;
+      c5: number | string;
+    }> = await this.dataSource.query(
+      `
+        SELECT
+          sc.user_id AS userId,
+          e.id AS essayId,
+          er.total_score AS totalScore,
+          er.comp1_score AS c1,
+          er.comp2_score AS c2,
+          er.comp3_score AS c3,
+          er.comp4_score AS c4,
+          er.comp5_score AS c5
+        FROM essays e
+        INNER JOIN student_course sc ON sc.user_id = e.user_id
+        INNER JOIN essay_reviews er
+          ON er.essay_id = e.id
+          AND er.review_type = 'HUMAN'
+          AND er.created_at = (
+            SELECT MAX(er2.created_at)
+            FROM essay_reviews er2
+            WHERE er2.essay_id = er.essay_id
+              AND er2.review_type = 'HUMAN'
+          )
+        WHERE sc.classId = ?
+          AND sc.applicationStatus = ?
+          AND e.status = 'REVIEWED'
+          AND e.submitted_at BETWEEN ? AND ?
+      `,
+      [classId, StatusApplication.Enrolled, monthStart, monthEnd],
+    );
+
+    // 2) Agrupa por aluno -> arrays de score
+    const byUser = new Map<
+      string,
+      {
+        totalScores: number[];
+        c1: number[];
+        c2: number[];
+        c3: number[];
+        c4: number[];
+        c5: number[];
+      }
+    >();
+    for (const r of rows) {
+      const u = byUser.get(r.userId) ?? {
+        totalScores: [],
+        c1: [],
+        c2: [],
+        c3: [],
+        c4: [],
+        c5: [],
+      };
+      u.totalScores.push(Number(r.totalScore));
+      u.c1.push(Number(r.c1));
+      u.c2.push(Number(r.c2));
+      u.c3.push(Number(r.c3));
+      u.c4.push(Number(r.c4));
+      u.c5.push(Number(r.c5));
+      byUser.set(r.userId, u);
+    }
+
+    // 3) Médias por aluno -> média entre alunos (peso 1 por aluno)
+    const avg = (arr: number[]) =>
+      arr.length === 0 ? 0 : arr.reduce((a, b) => a + b, 0) / arr.length;
+
+    const userAvgs = [...byUser.values()].map((u) => ({
+      total: avg(u.totalScores),
+      c1: avg(u.c1),
+      c2: avg(u.c2),
+      c3: avg(u.c3),
+      c4: avg(u.c4),
+      c5: avg(u.c5),
+    }));
+
+    const meanOf = (key: 'total' | 'c1' | 'c2' | 'c3' | 'c4' | 'c5') =>
+      userAvgs.length === 0
+        ? 0
+        : userAvgs.reduce((acc, u) => acc + u[key], 0) / userAvgs.length;
+
+    const geral = meanOf('total');
+    const competencias = {
+      c1: meanOf('c1'),
+      c2: meanOf('c2'),
+      c3: meanOf('c3'),
+      c4: meanOf('c4'),
+      c5: meanOf('c5'),
+    };
+
+    // 4) Contagens auxiliares
+    const essaysReviewedByHuman = new Set(rows.map((r) => r.essayId)).size;
+    const studentsWithAtLeastOneHumanReview = byUser.size;
+
+    const submittedTotalRow: Array<{ total: number | string }> =
+      await this.dataSource.query(
+        `
+          SELECT COUNT(*) AS total
+          FROM essays e
+          INNER JOIN student_course sc ON sc.user_id = e.user_id
+          WHERE sc.classId = ?
+            AND sc.applicationStatus = ?
+            AND e.submitted_at BETWEEN ? AND ?
+            AND e.status IN ('SUBMITTED', 'REVIEWED')
+        `,
+        [classId, StatusApplication.Enrolled, monthStart, monthEnd],
+      );
+    const essaysSubmittedTotal = Number(submittedTotalRow[0]?.total ?? 0);
+
+    const humanReviewRate =
+      essaysSubmittedTotal === 0
+        ? 0
+        : essaysReviewedByHuman / essaysSubmittedTotal;
+
+    return {
+      geral,
+      competencias,
+      studentsWithAtLeastOneHumanReview,
+      essaysReviewedByHuman,
+      essaysSubmittedTotal,
+      humanReviewRate,
+    };
+  }
+}

--- a/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.service.spec.ts
+++ b/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.service.spec.ts
@@ -1,0 +1,310 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { StatusApplication } from '../../studentCourse/enums/stastusApplication';
+import { ClassService } from '../class.service';
+import { ClassEssayAnalyticsRepository } from './class-essay-analytics.repository';
+import { ClassEssayAnalyticsService } from './class-essay-analytics.service';
+import { ClassEssaySnapshot } from './class-essay-snapshot.entity';
+
+const ACTIVE_START = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // 30 days ago
+const ACTIVE_END = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days from now
+const PAST_END = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000); // 10 days ago (ended)
+
+function makeClass(overrides: Partial<any> = {}): any {
+  return {
+    id: 'class-1',
+    name: 'Turma A',
+    coursePeriodStartDate: ACTIVE_START,
+    coursePeriodEndDate: ACTIVE_END,
+    students: [
+      {
+        id: 'sc-1',
+        userId: 'user-1',
+        status: StatusApplication.Enrolled,
+      },
+      {
+        id: 'sc-2',
+        userId: 'user-2',
+        status: StatusApplication.UnderReview,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeSnap(
+  overrides: Partial<ClassEssaySnapshot> = {},
+): ClassEssaySnapshot {
+  return {
+    id: 'snap-1',
+    classId: 'class-1',
+    month: '2026-05',
+    monthStart: new Date('2026-05-01T00:00:00.000Z'),
+    monthEnd: new Date('2026-05-31T23:59:59.000Z'),
+    userIds: ['user-1'],
+    payload: {
+      geral: 650,
+      competencias: { c1: 130, c2: 130, c3: 130, c4: 130, c5: 130 },
+      studentsWithAtLeastOneHumanReview: 1,
+      essaysReviewedByHuman: 1,
+      essaysSubmittedTotal: 1,
+      humanReviewRate: 1,
+    },
+    generatedAt: new Date('2026-05-18T12:00:00.000Z'),
+    sourceEssayCount: 1,
+    ...overrides,
+  } as unknown as ClassEssaySnapshot;
+}
+
+describe('ClassEssayAnalyticsService', () => {
+  let service: ClassEssayAnalyticsService;
+  let classService: jest.Mocked<ClassService>;
+  let repository: jest.Mocked<ClassEssayAnalyticsRepository>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ClassEssayAnalyticsService,
+        {
+          provide: ClassService,
+          useValue: {
+            findOneById: jest.fn(),
+          },
+        },
+        {
+          provide: ClassEssayAnalyticsRepository,
+          useValue: {
+            findOneByMonth: jest.fn(),
+            listByClass: jest.fn(),
+            upsert: jest.fn(),
+            aggregateMonth: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(ClassEssayAnalyticsService);
+    classService = module.get(ClassService) as jest.Mocked<ClassService>;
+    repository = module.get(
+      ClassEssayAnalyticsRepository,
+    ) as jest.Mocked<ClassEssayAnalyticsRepository>;
+  });
+
+  // ── listMonths ──────────────────────────────────────────────────────────────
+
+  describe('listMonths', () => {
+    it('returns months: [] and totalStudents=1 (one Enrolled) when repo returns empty array', async () => {
+      classService.findOneById.mockResolvedValue(makeClass());
+      repository.listByClass.mockResolvedValue([]);
+
+      const result = await service.listMonths('class-1', 'requester-1');
+
+      expect(result.months).toEqual([]);
+      expect(result.classId).toBe('class-1');
+      expect(result.className).toBe('Turma A');
+      expect(result.totalStudents).toBe(1);
+      expect(typeof result.coursePeriod.startDate).toBe('string');
+      expect(typeof result.coursePeriod.endDate).toBe('string');
+      expect(result.coursePeriod.startDate).toHaveLength(10);
+      expect(result.coursePeriod.endDate).toHaveLength(10);
+    });
+
+    it('maps a snapshot from repo into the output DTO converting Dates to ISO strings', async () => {
+      const snap = makeSnap();
+      classService.findOneById.mockResolvedValue(makeClass());
+      repository.listByClass.mockResolvedValue([snap]);
+
+      const result = await service.listMonths('class-1', 'requester-1');
+
+      expect(result.months).toHaveLength(1);
+      const m = result.months[0];
+      expect(m.month).toBe('2026-05');
+      expect(m.monthStart).toBe(snap.monthStart.toISOString());
+      expect(m.monthEnd).toBe(snap.monthEnd.toISOString());
+      expect(m.geral).toBe(650);
+      expect(m.competencias).toEqual(snap.payload.competencias);
+      expect(m.studentsWithAtLeastOneHumanReview).toBe(1);
+      expect(m.essaysReviewedByHuman).toBe(1);
+      expect(m.essaysSubmittedTotal).toBe(1);
+      expect(m.humanReviewRate).toBe(1);
+      expect(m.generatedAt).toBe(snap.generatedAt.toISOString());
+    });
+
+    it('throws BadRequestException when class has no coursePeriodStartDate', async () => {
+      classService.findOneById.mockResolvedValue(
+        makeClass({ coursePeriodStartDate: null }),
+      );
+
+      await expect(
+        service.listMonths('class-1', 'requester-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── getByMonth ──────────────────────────────────────────────────────────────
+
+  describe('getByMonth', () => {
+    it('throws NotFoundException when repo returns null', async () => {
+      classService.findOneById.mockResolvedValue(makeClass());
+      repository.findOneByMonth.mockResolvedValue(null);
+
+      await expect(
+        service.getByMonth('class-1', '2026-05', 'requester-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('returns merged shape with className and ISO-converted dates when repo returns a snapshot', async () => {
+      const snap = makeSnap();
+      classService.findOneById.mockResolvedValue(makeClass());
+      repository.findOneByMonth.mockResolvedValue(snap);
+
+      const result = await service.getByMonth(
+        'class-1',
+        '2026-05',
+        'requester-1',
+      );
+
+      expect(result.classId).toBe('class-1');
+      expect(result.className).toBe('Turma A');
+      expect(result.month).toBe('2026-05');
+      expect(result.monthStart).toBe(snap.monthStart.toISOString());
+      expect(result.monthEnd).toBe(snap.monthEnd.toISOString());
+      expect(result.geral).toBe(650);
+      expect(result.competencias).toEqual(snap.payload.competencias);
+      expect(result.studentsWithAtLeastOneHumanReview).toBe(1);
+      expect(result.essaysReviewedByHuman).toBe(1);
+      expect(result.essaysSubmittedTotal).toBe(1);
+      expect(result.humanReviewRate).toBe(1);
+      expect(result.generatedAt).toBe(snap.generatedAt.toISOString());
+    });
+  });
+
+  // ── refresh ─────────────────────────────────────────────────────────────────
+
+  describe('refresh', () => {
+    it('with scope=current invokes aggregateMonth and upsert exactly once', async () => {
+      classService.findOneById.mockResolvedValue(makeClass());
+      repository.aggregateMonth.mockResolvedValue({
+        geral: 600,
+        competencias: { c1: 120, c2: 120, c3: 120, c4: 120, c5: 120 },
+        studentsWithAtLeastOneHumanReview: 1,
+        essaysReviewedByHuman: 1,
+        essaysSubmittedTotal: 1,
+        humanReviewRate: 1,
+      });
+      repository.upsert.mockResolvedValue(makeSnap());
+
+      const result = await service.refresh('class-1', 'current', 'requester-1');
+
+      expect(repository.aggregateMonth).toHaveBeenCalledTimes(1);
+      expect(repository.upsert).toHaveBeenCalledTimes(1);
+      expect(result.enqueued).toHaveLength(1);
+      expect(result.enqueued[0].classId).toBe('class-1');
+      expect(result.enqueued[0].type).toBe('essay');
+      expect(result.estimatedSeconds).toBe(1);
+      const upsertArg = (repository.upsert as jest.Mock).mock.calls[0][0];
+      expect(upsertArg.userIds).toEqual(['user-1']);
+      expect(upsertArg.userIds).not.toContain('user-2');
+    });
+
+    it('with scope=all invokes upsert >= 1 times all with the same classId', async () => {
+      classService.findOneById.mockResolvedValue(
+        makeClass({
+          coursePeriodStartDate: new Date('2026-01-01'),
+          coursePeriodEndDate: new Date('2026-12-31'),
+        }),
+      );
+      repository.aggregateMonth.mockResolvedValue({
+        geral: 0,
+        competencias: { c1: 0, c2: 0, c3: 0, c4: 0, c5: 0 },
+        studentsWithAtLeastOneHumanReview: 0,
+        essaysReviewedByHuman: 0,
+        essaysSubmittedTotal: 0,
+        humanReviewRate: 0,
+      });
+      repository.upsert.mockResolvedValue(makeSnap());
+
+      const result = await service.refresh('class-1', 'all', 'requester-1');
+
+      expect(repository.upsert).toHaveBeenCalled();
+      const calls = repository.upsert.mock.calls;
+      expect(calls.length).toBeGreaterThanOrEqual(1);
+      expect(
+        calls.every((args) => (args[0] as any).classId === 'class-1'),
+      ).toBe(true);
+      expect(result.enqueued.every((i) => i.type === 'essay')).toBe(true);
+      expect(result.estimatedSeconds).toBe(result.enqueued.length * 1);
+    });
+
+    it('throws BadRequestException when period has ended', async () => {
+      classService.findOneById.mockResolvedValue(
+        makeClass({
+          coursePeriodStartDate: new Date('2020-01-01'),
+          coursePeriodEndDate: PAST_END,
+        }),
+      );
+
+      await expect(
+        service.refresh('class-1', 'current', 'requester-1'),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(repository.aggregateMonth).not.toHaveBeenCalled();
+      expect(repository.upsert).not.toHaveBeenCalled();
+    });
+
+    it('throws BadRequestException when class has no coursePeriodStartDate', async () => {
+      classService.findOneById.mockResolvedValue(
+        makeClass({ coursePeriodStartDate: null }),
+      );
+
+      await expect(
+        service.refresh('class-1', 'current', 'requester-1'),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── refreshOneMonthInternal ─────────────────────────────────────────────────
+
+  describe('refreshOneMonthInternal', () => {
+    it('calls aggregateMonth then upsert with the right payload, never touching classService', async () => {
+      const payload = {
+        geral: 700,
+        competencias: { c1: 140, c2: 140, c3: 140, c4: 140, c5: 140 },
+        studentsWithAtLeastOneHumanReview: 2,
+        essaysReviewedByHuman: 3,
+        essaysSubmittedTotal: 4,
+        humanReviewRate: 0.75,
+      };
+      repository.aggregateMonth.mockResolvedValue(payload);
+      repository.upsert.mockResolvedValue(makeSnap());
+
+      const monthStart = new Date('2026-05-01T00:00:00.000Z');
+      const monthEnd = new Date('2026-05-31T23:59:59.000Z');
+
+      await service.refreshOneMonthInternal({
+        classId: 'class-1',
+        month: '2026-05',
+        monthStart,
+        monthEnd,
+        userIds: ['user-1', 'user-2'],
+      });
+
+      expect(classService.findOneById).not.toHaveBeenCalled();
+      expect(repository.aggregateMonth).toHaveBeenCalledWith({
+        classId: 'class-1',
+        monthStart,
+        monthEnd,
+      });
+      expect(repository.upsert).toHaveBeenCalledTimes(1);
+      const upsertArg = repository.upsert.mock.calls[0][0] as any;
+      expect(upsertArg.classId).toBe('class-1');
+      expect(upsertArg.month).toBe('2026-05');
+      expect(upsertArg.monthStart).toEqual(monthStart);
+      expect(upsertArg.monthEnd).toEqual(monthEnd);
+      expect(upsertArg.userIds).toEqual(['user-1', 'user-2']);
+      expect(upsertArg.payload).toEqual(payload);
+      expect(upsertArg.sourceEssayCount).toBe(payload.essaysReviewedByHuman);
+      expect(upsertArg.generatedAt).toBeInstanceOf(Date);
+    });
+  });
+});

--- a/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.service.ts
+++ b/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.service.ts
@@ -1,0 +1,171 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  computeMonthWindow,
+  isActivePeriod,
+  listMonthsInPeriod,
+} from '../analytics/utils/month-window';
+import { ClassService } from '../class.service';
+import { StatusApplication } from '../../studentCourse/enums/stastusApplication';
+import { ClassEssayAnalyticsRepository } from './class-essay-analytics.repository';
+import { ClassEssaySnapshot } from './class-essay-snapshot.entity';
+import { EssayMonthDtoOutput } from './dtos/essay-month.dto.output';
+import {
+  EssayMonthSummary,
+  ListEssayMonthsDtoOutput,
+} from './dtos/list-essay-months.dto.output';
+import { RefreshEssayDtoOutput } from './dtos/refresh-essay.dto.output';
+
+interface RefreshOneMonthInternalInput {
+  classId: string;
+  month: string;
+  monthStart: Date;
+  monthEnd: Date;
+  userIds: string[];
+}
+
+@Injectable()
+export class ClassEssayAnalyticsService {
+  constructor(
+    private readonly classService: ClassService,
+    private readonly repository: ClassEssayAnalyticsRepository,
+  ) {}
+
+  async listMonths(
+    classId: string,
+    requesterId: string,
+  ): Promise<ListEssayMonthsDtoOutput> {
+    const klass = await this.classService.findOneById(classId, requesterId);
+    if (!klass.coursePeriodStartDate) {
+      throw new BadRequestException('Class has no course period');
+    }
+
+    const period = {
+      startDate: new Date(klass.coursePeriodStartDate),
+      endDate: new Date(klass.coursePeriodEndDate),
+    };
+    const snaps = await this.repository.listByClass(classId);
+
+    const months: EssayMonthSummary[] = snaps.map((s) =>
+      this.mapSnapshotToMonth(s),
+    );
+
+    return {
+      classId,
+      className: klass.name,
+      coursePeriod: {
+        startDate: period.startDate.toISOString().slice(0, 10),
+        endDate: period.endDate.toISOString().slice(0, 10),
+        isActive: isActivePeriod(period),
+      },
+      totalStudents: (klass.students ?? []).filter(
+        (s) => s.status === StatusApplication.Enrolled,
+      ).length,
+      months,
+    };
+  }
+
+  async getByMonth(
+    classId: string,
+    month: string,
+    requesterId: string,
+  ): Promise<EssayMonthDtoOutput> {
+    const klass = await this.classService.findOneById(classId, requesterId);
+    const snap = await this.repository.findOneByMonth(classId, month);
+    if (!snap) {
+      throw new NotFoundException('Snapshot not generated for this month');
+    }
+    return { classId, className: klass.name, ...this.mapSnapshotToMonth(snap) };
+  }
+
+  async refresh(
+    classId: string,
+    scope: 'current' | 'all',
+    requesterId: string,
+  ): Promise<RefreshEssayDtoOutput> {
+    const klass = await this.classService.findOneById(classId, requesterId);
+    if (!klass.coursePeriodStartDate) {
+      throw new BadRequestException('Class has no course period');
+    }
+    const period = {
+      startDate: new Date(klass.coursePeriodStartDate),
+      endDate: new Date(klass.coursePeriodEndDate),
+    };
+    if (!isActivePeriod(period)) {
+      throw new BadRequestException('Period not active');
+    }
+
+    const allMonths = listMonthsInPeriod(period);
+    const months =
+      scope === 'all' ? allMonths : [allMonths[allMonths.length - 1]];
+
+    const userIds = (klass.students ?? [])
+      .filter((s) => s.status === StatusApplication.Enrolled)
+      .map((s) => s.userId);
+
+    // Phase A: synchronous. Phase B will swap this for queue.enqueueMany.
+    for (const month of months) {
+      const { monthStart, monthEnd } = computeMonthWindow(month, period);
+      await this.refreshOneMonthInternal({
+        classId,
+        month,
+        monthStart,
+        monthEnd,
+        userIds,
+      });
+    }
+
+    return {
+      enqueued: months.map((m) => ({
+        classId,
+        month: m,
+        type: 'essay' as const,
+      })),
+      estimatedSeconds: months.length,
+    };
+  }
+
+  private mapSnapshotToMonth(snap: ClassEssaySnapshot): EssayMonthSummary {
+    return {
+      month: snap.month,
+      monthStart: snap.monthStart.toISOString(),
+      monthEnd: snap.monthEnd.toISOString(),
+      geral: snap.payload.geral,
+      competencias: snap.payload.competencias,
+      studentsWithAtLeastOneHumanReview:
+        snap.payload.studentsWithAtLeastOneHumanReview,
+      essaysReviewedByHuman: snap.payload.essaysReviewedByHuman,
+      essaysSubmittedTotal: snap.payload.essaysSubmittedTotal,
+      humanReviewRate: snap.payload.humanReviewRate,
+      generatedAt: snap.generatedAt.toISOString(),
+    };
+  }
+
+  /** Called by AnalyticsWorkerService when type='essay' (Phase B). No permission check — internal use only. */
+  async refreshOneMonthInternal({
+    classId,
+    month,
+    monthStart,
+    monthEnd,
+    userIds,
+  }: RefreshOneMonthInternalInput): Promise<ClassEssaySnapshot> {
+    const payload = await this.repository.aggregateMonth({
+      classId,
+      monthStart,
+      monthEnd,
+    });
+    return this.repository.upsert({
+      classId,
+      month,
+      monthStart,
+      monthEnd,
+      userIds,
+      payload,
+      generatedAt: new Date(),
+      sourceEssayCount: payload.essaysReviewedByHuman,
+    });
+  }
+}

--- a/src/modules/prepCourse/class/essay-analytics/class-essay-snapshot.entity.ts
+++ b/src/modules/prepCourse/class/essay-analytics/class-essay-snapshot.entity.ts
@@ -1,0 +1,50 @@
+import { Column, Entity, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import { BaseEntity } from '../../../../shared/modules/base/entity.base';
+import { Class } from '../class.entity';
+
+export interface ClassEssayPayload {
+  geral: number; // 0..1000
+  competencias: {
+    c1: number;
+    c2: number;
+    c3: number;
+    c4: number;
+    c5: number;
+  };
+  studentsWithAtLeastOneHumanReview: number;
+  essaysReviewedByHuman: number;
+  essaysSubmittedTotal: number;
+  humanReviewRate: number; // 0..1
+}
+
+@Entity('class_essay_snapshots')
+@Unique(['classId', 'month'])
+export class ClassEssaySnapshot extends BaseEntity {
+  @Column({ name: 'class_id', length: 36 })
+  classId: string;
+
+  @Column({ length: 7 })
+  month: string;
+
+  @Column({ name: 'month_start', type: 'timestamp' })
+  monthStart: Date;
+
+  @Column({ name: 'month_end', type: 'timestamp' })
+  monthEnd: Date;
+
+  @Column({ name: 'user_ids', type: 'json' })
+  userIds: string[];
+
+  @Column({ type: 'json' })
+  payload: ClassEssayPayload;
+
+  @Column({ name: 'generated_at', type: 'timestamp' })
+  generatedAt: Date;
+
+  @Column({ name: 'source_essay_count' })
+  sourceEssayCount: number;
+
+  @ManyToOne(() => Class, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'class_id' })
+  class: Class;
+}

--- a/src/modules/prepCourse/class/essay-analytics/dtos/essay-month.dto.output.ts
+++ b/src/modules/prepCourse/class/essay-analytics/dtos/essay-month.dto.output.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CompMeans } from './list-essay-months.dto.output';
+
+/**
+ * Dados detalhados de redações de uma turma em um mês específico.
+ *
+ * **Contrato de datas:** `month` é uma string ISO 8601 no formato YYYY-MM-DD;
+ * `generatedAt` é um timestamp ISO 8601 completo. A camada de service é
+ * responsável por converter `Date` -> ISO string antes de retornar.
+ */
+export class EssayMonthDtoOutput {
+  @ApiProperty() classId: string;
+  @ApiProperty() className: string;
+  @ApiProperty({ type: String, format: 'date', example: '2026-05-01' })
+  month: string;
+  @ApiProperty() monthStart: string;
+  @ApiProperty() monthEnd: string;
+  @ApiProperty() geral: number;
+  @ApiProperty({ type: CompMeans }) competencias: CompMeans;
+  @ApiProperty() studentsWithAtLeastOneHumanReview: number;
+  @ApiProperty() essaysReviewedByHuman: number;
+  @ApiProperty() essaysSubmittedTotal: number;
+  @ApiProperty() humanReviewRate: number;
+  @ApiProperty({
+    type: String,
+    format: 'date-time',
+    example: '2026-05-18T12:34:56.000Z',
+  })
+  generatedAt: string;
+}

--- a/src/modules/prepCourse/class/essay-analytics/dtos/list-essay-months.dto.output.ts
+++ b/src/modules/prepCourse/class/essay-analytics/dtos/list-essay-months.dto.output.ts
@@ -1,0 +1,59 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CompMeans {
+  @ApiProperty() c1: number;
+  @ApiProperty() c2: number;
+  @ApiProperty() c3: number;
+  @ApiProperty() c4: number;
+  @ApiProperty() c5: number;
+}
+
+/**
+ * Informações do período do cursinho associado à turma.
+ *
+ * **Contrato de datas:** `start` e `end` são strings ISO 8601 no formato
+ * YYYY-MM-DD. A camada de service é responsável por converter `Date` ->
+ * ISO string antes de retornar.
+ */
+export class EssayCoursePeriodInfo {
+  @ApiProperty({ type: String, format: 'date', example: '2026-01-01' })
+  startDate: string;
+  @ApiProperty({ type: String, format: 'date', example: '2026-12-31' })
+  endDate: string;
+  @ApiProperty() isActive: boolean;
+}
+
+/**
+ * Resumo agregado de um mês de redações.
+ *
+ * **Contrato de datas:** os campos `month`, `generatedAt` (e `start`/`end` em
+ * `EssayCoursePeriodInfo`) são strings ISO 8601. A camada de service é
+ * responsável por converter `Date` -> ISO string antes de retornar.
+ */
+export class EssayMonthSummary {
+  @ApiProperty({ type: String, format: 'date', example: '2026-05-01' })
+  month: string;
+  @ApiProperty() monthStart: string;
+  @ApiProperty() monthEnd: string;
+  @ApiProperty() geral: number;
+  @ApiProperty({ type: CompMeans }) competencias: CompMeans;
+  @ApiProperty() studentsWithAtLeastOneHumanReview: number;
+  @ApiProperty() essaysReviewedByHuman: number;
+  @ApiProperty() essaysSubmittedTotal: number;
+  @ApiProperty() humanReviewRate: number;
+  @ApiProperty({
+    type: String,
+    format: 'date-time',
+    example: '2026-05-18T12:34:56.000Z',
+  })
+  generatedAt: string;
+}
+
+export class ListEssayMonthsDtoOutput {
+  @ApiProperty() classId: string;
+  @ApiProperty() className: string;
+  @ApiProperty({ type: EssayCoursePeriodInfo })
+  coursePeriod: EssayCoursePeriodInfo;
+  @ApiProperty() totalStudents: number;
+  @ApiProperty({ type: [EssayMonthSummary] }) months: EssayMonthSummary[];
+}

--- a/src/modules/prepCourse/class/essay-analytics/dtos/refresh-essay.dto.output.ts
+++ b/src/modules/prepCourse/class/essay-analytics/dtos/refresh-essay.dto.output.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class EssayEnqueuedItem {
+  @ApiProperty() classId: string;
+  @ApiProperty() month: string;
+  @ApiProperty({ enum: ['essay'] }) type: 'essay';
+}
+
+export class RefreshEssayDtoOutput {
+  @ApiProperty({ type: [EssayEnqueuedItem] }) enqueued: EssayEnqueuedItem[];
+  @ApiProperty() estimatedSeconds: number;
+}

--- a/test/class-essay-analytics.e2e-spec.ts
+++ b/test/class-essay-analytics.e2e-spec.ts
@@ -1,0 +1,683 @@
+import { INestApplication } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AppModule } from 'src/app.module';
+import { Essay } from 'src/modules/essay/entities/essay.entity';
+import { EssayReview } from 'src/modules/essay/entities/essay-review.entity';
+import { EssayTheme } from 'src/modules/essay/entities/essay-theme.entity';
+import { EssayInputType } from 'src/modules/essay/enums/essay-input-type.enum';
+import { EssayStatus } from 'src/modules/essay/enums/essay-status.enum';
+import { ReviewType } from 'src/modules/essay/enums/review-type.enum';
+import { GeoService } from 'src/modules/geo/geo.service';
+import { LogGeoRepository } from 'src/modules/geo/log-geo/log-geo.repository';
+import { ClassEssaySnapshot } from 'src/modules/prepCourse/class/essay-analytics/class-essay-snapshot.entity';
+import { ClassRepository } from 'src/modules/prepCourse/class/class.repository';
+import { CoursePeriodService } from 'src/modules/prepCourse/coursePeriod/course-period.service';
+import { InscriptionCourseService } from 'src/modules/prepCourse/InscriptionCourse/inscription-course.service';
+import { PartnerPrepCourseDtoInput } from 'src/modules/prepCourse/partnerPrepCourse/dtos/create-partner-prep-course.input.dto';
+import { LogPartnerRepository } from 'src/modules/prepCourse/partnerPrepCourse/log-partner/log-partner.repository';
+import { PartnerPrepCourseService } from 'src/modules/prepCourse/partnerPrepCourse/partner-prep-course.service';
+import { StatusApplication } from 'src/modules/prepCourse/studentCourse/enums/stastusApplication';
+import { StudentCourseRepository } from 'src/modules/prepCourse/studentCourse/student-course.repository';
+import { StudentCourseService } from 'src/modules/prepCourse/studentCourse/student-course.service';
+import { SubmissionService } from 'src/modules/vcnafacul-form/submission/submission.service';
+import { CreateRoleDtoInput } from 'src/modules/role/dto/create-role.dto';
+import { Role } from 'src/modules/role/role.entity';
+import { RoleService } from 'src/modules/role/role.service';
+import { UserRepository } from 'src/modules/user/user.repository';
+import { UserService } from 'src/modules/user/user.service';
+import { FormService } from 'src/modules/vcnafacul-form/form/form.service';
+import { CacheService } from 'src/shared/modules/cache/cache.service';
+import { HttpServiceAxiosFactory } from 'src/shared/services/axios/http-service-axios.factory';
+import { BlobService } from 'src/shared/services/blob/blob-service';
+import { EmailService } from 'src/shared/services/email/email.service';
+import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
+import { DiscordWebhook } from 'src/shared/services/webhooks/discord';
+import * as request from 'supertest';
+import { Repository } from 'typeorm';
+import { CreateGeoDTOInputFaker } from './faker/create-geo.dto.input.faker';
+import { CreateInscriptionCourseDTOInputFaker } from './faker/create-inscription-course.dto.faker';
+import { createStudentCourseDTOInputFaker } from './faker/create-student-course.dto.input.faker';
+import { CreateUserDtoInputFaker } from './faker/create-user.dto.input.faker';
+import { createNestAppTest } from './utils/createNestAppTest';
+
+jest.mock('src/shared/services/email/email.service');
+jest.mock('src/shared/services/blob/blob-service.ts');
+jest.mock('src/shared/services/webhooks/discord.ts');
+
+describe('ClassEssayAnalytics (e2e)', () => {
+  let app: INestApplication;
+  let userService: UserService;
+  let userRepository: UserRepository;
+  let geoService: GeoService;
+  let jwtService: JwtService;
+  let roleService: RoleService;
+  let partnerService: PartnerPrepCourseService;
+  let emailService: EmailService;
+  let classRepository: ClassRepository;
+  let coursePeriodService: CoursePeriodService;
+  let blobService: BlobService;
+  let logPartnerRepository: LogPartnerRepository;
+  let logGeoRepository: LogGeoRepository;
+  let inscriptionCourseService: InscriptionCourseService;
+  let studentCourseService: StudentCourseService;
+  let studentCourseRepository: StudentCourseRepository;
+  let submissionService: SubmissionService;
+  let cacheService: CacheService;
+  let essayRepo: Repository<Essay>;
+  let essayReviewRepo: Repository<EssayReview>;
+  let essayThemeRepo: Repository<EssayTheme>;
+  let snapshotRepo: Repository<ClassEssaySnapshot>;
+
+  // Role with both gerenciarTurmas and visualizarTurmas
+  let analyticsRole: Role = null;
+
+  const discordWebhookMock = {
+    sendMessage: jest.fn(),
+  };
+
+  const formServiceMock = {
+    hasActiveForm: jest.fn().mockResolvedValue(true),
+    createFormFull: jest.fn().mockResolvedValue('hashKeyFile'),
+    getFormFullByInscriptionId: jest.fn().mockResolvedValue('hashKeyFile'),
+    createPartnerForm: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const simuladoHttpMock = {
+    listUserGroupAggregates: jest.fn().mockResolvedValue([]),
+    getUserGroupAggregateByMonth: jest.fn().mockResolvedValue(null),
+    calculateUserGroupAggregate: jest.fn().mockResolvedValue({}),
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+      providers: [EmailService],
+    })
+      .overrideProvider(DiscordWebhook)
+      .useValue(discordWebhookMock)
+      .overrideProvider(FormService)
+      .useValue(formServiceMock)
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .overrideProvider(SimuladoHttpService)
+      .useValue(simuladoHttpMock)
+      .overrideProvider(HttpServiceAxiosFactory)
+      .useValue({ create: () => ({}) })
+      .compile();
+
+    app = createNestAppTest(moduleFixture);
+    userService = moduleFixture.get<UserService>(UserService);
+    userRepository = moduleFixture.get<UserRepository>(UserRepository);
+    geoService = moduleFixture.get<GeoService>(GeoService);
+    jwtService = moduleFixture.get<JwtService>(JwtService);
+    roleService = moduleFixture.get<RoleService>(RoleService);
+    emailService = moduleFixture.get<EmailService>(EmailService);
+    partnerService = moduleFixture.get<PartnerPrepCourseService>(
+      PartnerPrepCourseService,
+    );
+    classRepository = moduleFixture.get<ClassRepository>(ClassRepository);
+    coursePeriodService =
+      moduleFixture.get<CoursePeriodService>(CoursePeriodService);
+    blobService = moduleFixture.get<BlobService>('BlobService');
+    logPartnerRepository =
+      moduleFixture.get<LogPartnerRepository>(LogPartnerRepository);
+    logGeoRepository = moduleFixture.get<LogGeoRepository>(LogGeoRepository);
+    inscriptionCourseService = moduleFixture.get<InscriptionCourseService>(
+      InscriptionCourseService,
+    );
+    studentCourseService =
+      moduleFixture.get<StudentCourseService>(StudentCourseService);
+    studentCourseRepository = moduleFixture.get<StudentCourseRepository>(
+      StudentCourseRepository,
+    );
+    submissionService = moduleFixture.get<SubmissionService>(SubmissionService);
+    cacheService = moduleFixture.get<CacheService>(CacheService);
+    essayRepo = moduleFixture.get<Repository<Essay>>(getRepositoryToken(Essay));
+    essayReviewRepo = moduleFixture.get<Repository<EssayReview>>(
+      getRepositoryToken(EssayReview),
+    );
+    essayThemeRepo = moduleFixture.get<Repository<EssayTheme>>(
+      getRepositoryToken(EssayTheme),
+    );
+    snapshotRepo = moduleFixture.get<Repository<ClassEssaySnapshot>>(
+      getRepositoryToken(ClassEssaySnapshot),
+    );
+
+    jest.spyOn(emailService, 'sendEmailGeo').mockImplementation(async () => {});
+    jest
+      .spyOn(emailService, 'sendCreateUser')
+      .mockImplementation(async () => {});
+    jest
+      .spyOn(blobService, 'uploadFile')
+      .mockImplementation(async () => 'hashKeyFile');
+    jest
+      .spyOn(blobService, 'getFile')
+      .mockImplementation(async () => Buffer.from('fake'));
+    jest
+      .spyOn(logPartnerRepository, 'create')
+      .mockImplementation(async () => ({}) as any);
+    jest
+      .spyOn(logGeoRepository, 'create')
+      .mockImplementation(async () => ({}) as any);
+
+    // Disable cache writes so classService.findOneById doesn't serve stale snapshots
+    // when the test mutates students after the first read.
+    jest.spyOn(cacheService, 'set').mockImplementation(async () => {});
+    jest.spyOn(cacheService, 'get').mockImplementation(async () => undefined);
+
+    // Avoid HTTP calls to vcnafacul-form when creating students
+    jest
+      .spyOn(submissionService, 'createSubmission')
+      .mockImplementation(async () => 'hashKeyFile');
+
+    await app.init();
+
+    // Role with gerenciarTurmas + visualizarTurmas (for analytics endpoints)
+    analyticsRole = await roleService.findOneBy({
+      name: 'custom_role_essay_analytics',
+    });
+    if (!analyticsRole) {
+      const newRole = new CreateRoleDtoInput();
+      newRole.name = 'custom_role_essay_analytics';
+      newRole.gerenciarTurmas = true;
+      newRole.visualizarTurmas = true;
+      analyticsRole = await roleService.create(newRole);
+    }
+  });
+
+  afterAll(async () => {
+    if (app) await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Re-apply default mock implementations after clearAllMocks
+    simuladoHttpMock.listUserGroupAggregates.mockResolvedValue([]);
+    simuladoHttpMock.getUserGroupAggregateByMonth.mockResolvedValue(null);
+    simuladoHttpMock.calculateUserGroupAggregate.mockResolvedValue({});
+    // Re-apply cache mocks (cleared by clearAllMocks)
+    jest.spyOn(cacheService, 'set').mockImplementation(async () => {});
+    jest.spyOn(cacheService, 'get').mockImplementation(async () => undefined);
+    jest
+      .spyOn(submissionService, 'createSubmission')
+      .mockImplementation(async () => 'hashKeyFile');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a partner + user with analyticsRole
+   */
+  const createPartnerWithAnalyticsRole = async () => {
+    const geoDto = CreateGeoDTOInputFaker();
+    const geo = await geoService.create(geoDto);
+
+    const userDto = CreateUserDtoInputFaker();
+    await userService.create(userDto);
+    const user = await userRepository.findOneBy({ email: userDto.email });
+
+    user.role = analyticsRole;
+    await userRepository.update(user);
+
+    const dto: PartnerPrepCourseDtoInput = {
+      geoId: geo.id,
+      representative: user.id,
+    };
+    const partner = await partnerService.create(dto, user.id);
+    return { user, partner };
+  };
+
+  /**
+   * Creates a user without any special permissions (no role)
+   */
+  const createUnprivilegedUser = async () => {
+    const userDto = CreateUserDtoInputFaker();
+    await userService.create(userDto);
+    return userRepository.findOneBy({ email: userDto.email });
+  };
+
+  /**
+   * Creates a class with an ACTIVE course period (startDate <= today <= endDate)
+   */
+  const createClassWithActivePeriod = async (userId: string) => {
+    const today = new Date();
+    const startDate = new Date(today);
+    startDate.setMonth(startDate.getMonth() - 3); // 3 months ago
+    const endDate = new Date(today);
+    endDate.setMonth(endDate.getMonth() + 9); // 9 months from now
+
+    const coursePeriod = await coursePeriodService.create(
+      {
+        name: `Período Ativo Essay ${Date.now()}`,
+        startDate,
+        endDate,
+      },
+      userId,
+    );
+
+    const classDto = {
+      name: `Turma Essay Analytics ${Date.now()}`,
+      description: 'Turma de teste essay analytics',
+      coursePeriodId: coursePeriod.id,
+    };
+
+    const createdClass = await request(app.getHttpServer())
+      .post('/class')
+      .send(classDto)
+      .set({
+        Authorization: `Bearer ${await jwtService.signAsync(
+          { user: { id: userId } },
+          { expiresIn: '2h' },
+        )}`,
+      })
+      .expect(201);
+
+    return { classId: createdClass.body.id as string, coursePeriod };
+  };
+
+  /**
+   * Creates a class with an ENDED course period (endDate < today)
+   */
+  const createClassWithEndedPeriod = async (userId: string) => {
+    const today = new Date();
+    const startDate = new Date(today);
+    startDate.setFullYear(startDate.getFullYear() - 2); // 2 years ago
+    const endDate = new Date(today);
+    endDate.setMonth(endDate.getMonth() - 1); // 1 month ago
+
+    const coursePeriod = await coursePeriodService.create(
+      {
+        name: `Período Encerrado Essay ${Date.now()}`,
+        startDate,
+        endDate,
+      },
+      userId,
+    );
+
+    const classDto = {
+      name: `Turma Essay Encerrada ${Date.now()}`,
+      description: 'Turma de teste essay período encerrado',
+      coursePeriodId: coursePeriod.id,
+    };
+
+    const createdClass = await request(app.getHttpServer())
+      .post('/class')
+      .send(classDto)
+      .set({
+        Authorization: `Bearer ${await jwtService.signAsync(
+          { user: { id: userId } },
+          { expiresIn: '2h' },
+        )}`,
+      })
+      .expect(201);
+
+    return { classId: createdClass.body.id as string, coursePeriod };
+  };
+
+  /**
+   * Creates a student bound to the given inscription.
+   * Returns both the StudentCourse id and the underlying user.id so seeded
+   * essays can reference the right user FK without re-querying.
+   */
+  const createStudent = async (
+    inscriptionId: string,
+  ): Promise<{ id: string; userId: string }> => {
+    const userStudentDto = CreateUserDtoInputFaker();
+    await userService.create(userStudentDto);
+    const userStudent = await userRepository.findOneBy({
+      email: userStudentDto.email,
+    });
+    const studentDto = createStudentCourseDTOInputFaker(
+      userStudent.id,
+      inscriptionId,
+    );
+    const created = await studentCourseService.create(studentDto);
+    return { id: created.id, userId: userStudent.id };
+  };
+
+  /**
+   * Enrolls a freshly-created student into the given class (sets applicationStatus = Enrolled).
+   * confirmEnrolled requires the student to be in DeclaredInterest first, so we bump it manually.
+   */
+  const enrollStudentInClass = async (studentId: string, classId: string) => {
+    const student = await studentCourseService.findOneBy({ id: studentId });
+    student.applicationStatus = StatusApplication.DeclaredInterest;
+    await studentCourseRepository.update(student);
+    await studentCourseService.confirmEnrolled(studentId, classId);
+  };
+
+  /**
+   * Assigns a student to the given class but keeps their status as UnderReview (i.e. "Pending").
+   * Used to test that the aggregation filters out non-Enrolled students.
+   */
+  const addPendingStudentToClass = async (
+    studentId: string,
+    classId: string,
+  ) => {
+    await studentCourseService.updateClass(studentId, classId);
+    // updateClass does not modify applicationStatus; it stays UnderReview (default).
+    const fresh = await studentCourseRepository.findOneBy({ id: studentId });
+    expect(fresh.applicationStatus).toBe(StatusApplication.UnderReview);
+  };
+
+  /**
+   * Creates an essay theme with default values. Each call uses a unique title.
+   */
+  const createTheme = async (creatorId: string, label = 'A') => {
+    const theme = essayThemeRepo.create({
+      title: `Tema ${label} ${Date.now()}-${Math.random()}`,
+      motivationalText: 'Texto motivacional de teste',
+      weekStart: new Date('2025-01-01'),
+      weekEnd: new Date('2025-12-31'),
+      active: true,
+      createdBy: creatorId,
+    });
+    return await essayThemeRepo.save(theme);
+  };
+
+  /**
+   * Creates a REVIEWED essay submitted "now" for the given (user, theme).
+   */
+  const createReviewedEssay = async (userId: string, themeId: string) => {
+    const essay = essayRepo.create({
+      userId,
+      themeId,
+      title: 'Título da redação',
+      text: 'Texto da redação suficientemente longo para um teste...',
+      inputType: EssayInputType.TYPED,
+      status: EssayStatus.REVIEWED,
+      wordCount: 250,
+      submittedAt: new Date(),
+    });
+    return await essayRepo.save(essay);
+  };
+
+  /**
+   * Creates an EssayReview for the given essay. Component scores are distributed
+   * evenly so they sum (roughly) to totalScore.
+   */
+  const createReview = async (
+    essayId: string,
+    reviewType: ReviewType,
+    totalScore: number,
+  ) => {
+    const each = Math.floor(totalScore / 5);
+    const review = essayReviewRepo.create({
+      essayId,
+      reviewType,
+      reviewerId: null,
+      comp1Score: each,
+      comp1Feedback: '',
+      comp1Suggestion: '',
+      comp2Score: each,
+      comp2Feedback: '',
+      comp2Suggestion: '',
+      comp3Score: each,
+      comp3Feedback: '',
+      comp3Suggestion: '',
+      comp4Score: each,
+      comp4Feedback: '',
+      comp4Suggestion: '',
+      comp5Score: each,
+      comp5Feedback: '',
+      comp5Suggestion: '',
+      totalScore,
+      generalComment: '',
+    });
+    return await essayReviewRepo.save(review);
+  };
+
+  const currentMonth = () => new Date().toISOString().slice(0, 7);
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Scenario 1: 403 without token / 403 without visualizarTurmas
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('should return 403 when no bearer token is provided', async () => {
+    return request(app.getHttpServer())
+      .get('/class/some-class-id/analytics/redacao')
+      .expect(403);
+  });
+
+  it('should return 403 when user lacks visualizarTurmas permission', async () => {
+    const unprivileged = await createUnprivilegedUser();
+    const token = await jwtService.signAsync(
+      { user: { id: unprivileged.id } },
+      { expiresIn: '2h' },
+    );
+
+    return request(app.getHttpServer())
+      .get('/class/some-class-id/analytics/redacao')
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(403);
+  }, 30000);
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Scenario 2: 200 with empty months list when no snapshots exist
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('should return 200 with empty months list when no snapshots exist', async () => {
+    const { user } = await createPartnerWithAnalyticsRole();
+    const token = await jwtService.signAsync(
+      { user: { id: user.id } },
+      { expiresIn: '2h' },
+    );
+
+    const { classId } = await createClassWithActivePeriod(user.id);
+
+    const response = await request(app.getHttpServer())
+      .get(`/class/${classId}/analytics/redacao`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(200);
+
+    expect(response.body.months).toEqual([]);
+    expect(response.body.coursePeriod).toBeDefined();
+    expect(response.body.coursePeriod.isActive).toBe(true);
+    expect(response.body.classId).toBe(classId);
+  }, 30000);
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Scenario 3: 404 when the requested month has no snapshot
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('should return 404 when no snapshot exists for the requested month', async () => {
+    const { user } = await createPartnerWithAnalyticsRole();
+    const token = await jwtService.signAsync(
+      { user: { id: user.id } },
+      { expiresIn: '2h' },
+    );
+
+    const { classId } = await createClassWithActivePeriod(user.id);
+
+    return request(app.getHttpServer())
+      .get(`/class/${classId}/analytics/redacao/2026-05`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(404);
+  }, 30000);
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Scenarios 4 + 5: Seeded refresh produces correct aggregation
+  //
+  //  - 3 Enrolled students with essays this month:
+  //      * student1: HUMAN review, totalScore=800
+  //      * student2: HUMAN review, totalScore=600
+  //      * student3: AI review only (no HUMAN review)
+  //  - 1 Pending (UnderReview) student also in the same class with an essay +
+  //    HUMAN review (totalScore=1000) — must be excluded.
+  //
+  //  Expected snapshot:
+  //    geral                            = (800 + 600) / 2 = 700
+  //    studentsWithAtLeastOneHumanReview= 2
+  //    essaysReviewedByHuman            = 2
+  //    essaysSubmittedTotal             = 3 (all 3 Enrolled, regardless of review type)
+  //    humanReviewRate                  = 2 / 3
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('should aggregate only HUMAN-reviewed essays from Enrolled students of the class', async () => {
+    const { user } = await createPartnerWithAnalyticsRole();
+    const token = await jwtService.signAsync(
+      { user: { id: user.id } },
+      { expiresIn: '2h' },
+    );
+
+    const { classId } = await createClassWithActivePeriod(user.id);
+
+    // Seed inscription + students
+    const inscription = await inscriptionCourseService.create(
+      CreateInscriptionCourseDTOInputFaker(),
+      user.id,
+    );
+
+    const s1 = await createStudent(inscription.id);
+    const s2 = await createStudent(inscription.id);
+    const s3 = await createStudent(inscription.id);
+    const sPending = await createStudent(inscription.id);
+
+    await enrollStudentInClass(s1.id, classId);
+    await enrollStudentInClass(s2.id, classId);
+    await enrollStudentInClass(s3.id, classId);
+    await addPendingStudentToClass(sPending.id, classId);
+
+    // Re-fetch userIds (some test envs create user inline; we trust dto.userId)
+    const userId1 = s1.userId;
+    const userId2 = s2.userId;
+    const userId3 = s3.userId;
+    const userIdPending = sPending.userId;
+
+    // Create distinct themes (Essay has UNIQUE(userId, themeId) — different users
+    // could share a theme, but to be safe we use a fresh theme per essay).
+    const themeA = await createTheme(user.id, 'A');
+    const themeB = await createTheme(user.id, 'B');
+    const themeC = await createTheme(user.id, 'C');
+    const themeD = await createTheme(user.id, 'D');
+
+    // Enrolled student 1: HUMAN review, score 800
+    const e1 = await createReviewedEssay(userId1, themeA.id);
+    await createReview(e1.id, ReviewType.HUMAN, 800);
+
+    // Enrolled student 2: HUMAN review, score 600
+    const e2 = await createReviewedEssay(userId2, themeB.id);
+    await createReview(e2.id, ReviewType.HUMAN, 600);
+
+    // Enrolled student 3: AI review only (no HUMAN). Essay still counts in
+    // essaysSubmittedTotal because status is REVIEWED.
+    const e3 = await createReviewedEssay(userId3, themeC.id);
+    await createReview(e3.id, ReviewType.AI, 700);
+
+    // Pending student (UnderReview): essay + HUMAN review — must be excluded.
+    const ePending = await createReviewedEssay(userIdPending, themeD.id);
+    await createReview(ePending.id, ReviewType.HUMAN, 1000);
+
+    // Trigger refresh (synchronous in Phase A)
+    const refreshResp = await request(app.getHttpServer())
+      .post(`/class/${classId}/analytics/redacao/refresh`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(202);
+
+    expect(refreshResp.body.enqueued).toHaveLength(1);
+    expect(refreshResp.body.enqueued[0].classId).toBe(classId);
+    expect(refreshResp.body.enqueued[0].type).toBe('essay');
+    const month = refreshResp.body.enqueued[0].month as string;
+    expect(month).toMatch(/^\d{4}-\d{2}$/);
+    expect(month).toBe(currentMonth());
+
+    // Fetch the produced snapshot
+    const getResp = await request(app.getHttpServer())
+      .get(`/class/${classId}/analytics/redacao/${month}`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(200);
+
+    expect(getResp.body.month).toBe(month);
+    expect(getResp.body.geral).toBe(700);
+    expect(getResp.body.studentsWithAtLeastOneHumanReview).toBe(2);
+    expect(getResp.body.essaysReviewedByHuman).toBe(2);
+    expect(getResp.body.essaysSubmittedTotal).toBe(3);
+    expect(getResp.body.humanReviewRate).toBeCloseTo(2 / 3, 5);
+
+    // Competencias: each comp gets totalScore/5 floor — verify they reflect the
+    // same 2-user mean: ((800/5)+(600/5))/2 = (160+120)/2 = 140
+    expect(getResp.body.competencias.c1).toBeCloseTo(140, 5);
+    expect(getResp.body.competencias.c5).toBeCloseTo(140, 5);
+  }, 60000);
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Scenario 6: Refresh is idempotent (upsert, no duplicate row)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('should upsert the snapshot idempotently when refreshed twice', async () => {
+    const { user } = await createPartnerWithAnalyticsRole();
+    const token = await jwtService.signAsync(
+      { user: { id: user.id } },
+      { expiresIn: '2h' },
+    );
+
+    const { classId } = await createClassWithActivePeriod(user.id);
+
+    // Minimal seed: one Enrolled student with a HUMAN-reviewed essay
+    const inscription = await inscriptionCourseService.create(
+      CreateInscriptionCourseDTOInputFaker(),
+      user.id,
+    );
+    const s1 = await createStudent(inscription.id);
+    await enrollStudentInClass(s1.id, classId);
+
+    const theme = await createTheme(user.id, 'idem');
+    const e1 = await createReviewedEssay(s1.userId, theme.id);
+    await createReview(e1.id, ReviewType.HUMAN, 500);
+
+    // First refresh
+    await request(app.getHttpServer())
+      .post(`/class/${classId}/analytics/redacao/refresh`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(202);
+
+    // Second refresh on the same month should not duplicate the row
+    await request(app.getHttpServer())
+      .post(`/class/${classId}/analytics/redacao/refresh`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(202);
+
+    const month = currentMonth();
+    const rows = await snapshotRepo.find({ where: { classId, month } });
+    expect(rows).toHaveLength(1);
+
+    // listMonths should also return a single entry
+    const listResp = await request(app.getHttpServer())
+      .get(`/class/${classId}/analytics/redacao`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(200);
+
+    const monthEntries = (
+      listResp.body.months as Array<{ month: string }>
+    ).filter((m) => m.month === month);
+    expect(monthEntries).toHaveLength(1);
+  }, 60000);
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Scenario 7: 400 when the course period has ended
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('should return 400 when trying to refresh a class with an ended period', async () => {
+    const { user } = await createPartnerWithAnalyticsRole();
+    const token = await jwtService.signAsync(
+      { user: { id: user.id } },
+      { expiresIn: '2h' },
+    );
+
+    const { classId } = await createClassWithEndedPeriod(user.id);
+
+    return request(app.getHttpServer())
+      .post(`/class/${classId}/analytics/redacao/refresh`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(400);
+  }, 30000);
+
+  // Suppress unused-variable warnings for fixtures we keep available for
+  // potential follow-up assertions (e.g. classRepository for direct DB checks).
+  void classRepository;
+});


### PR DESCRIPTION
## Summary

Implementa **Fase A** da feature `turma-analytics-redacao` (análogo a `turma-analytics-simulado` Fase A): snapshots mensais agregados de redações ENEM por turma, com cálculo síncrono local. Fase B (fila Redis + workers) e Fase C (frontend) virão em PRs separados.

**Endpoints novos (`/class/:id/analytics/redacao`):**
- `GET /` → lista meses com snapshot + período do curso + totalStudents Enrolled
- `GET /:month` → snapshot completo (`geral`, `competencias.c1..c5`, `studentsWithAtLeastOneHumanReview`, `essaysReviewedByHuman`, `essaysSubmittedTotal`, `humanReviewRate`) ou 404
- `POST /refresh[?all=true]` → recalcula 1 mês (current) ou todos os meses do período; síncrono nesta fase

**Regras de agregação:**
- Considera apenas alunos `applicationStatus = Matriculado` da turma
- Inclui apenas redações com `status = REVIEWED` e revisão `review_type = HUMAN` (mais recente por essay)
- Média de **2 estágios**: média por aluno (peso 1 por redação), depois média entre alunos (peso 1 por aluno)
- `humanReviewRate = essaysReviewedByHuman / essaysSubmittedTotal` (status SUBMITTED ou REVIEWED), com proteção contra divisão por zero

**Arquivos principais:**
- `src/db/migrations/<TS>-class-essay-snapshots.ts` — tabela `class_essay_snapshots` com `payload JSON` + `UNIQUE(class_id, month)` + FK `class_id` → `classes(id)`
- `src/modules/prepCourse/class/essay-analytics/` — entity, DTOs, repository (SQL JOIN), service (com `refreshOneMonthInternal` reservado para Fase B), controller, module
- `test/class-essay-analytics.e2e-spec.ts` — 7 cenários end-to-end contra MySQL real

**Reuso:** `computeMonthWindow`, `listMonthsInPeriod`, `isActivePeriod` (já em `analytics/utils/month-window.ts` da Fase B simulado).

## Test Plan

- [x] Migration roda sem erros (`npm run migration:run` em DB local)
- [x] `npm run test -- class-essay-analytics.service.spec.ts` — 10/10 unitários verdes
- [x] `npm run test:local -- class-essay-analytics.e2e-spec.ts` — 7/7 e2e verdes contra MySQL real (Docker port 3307)
  - 403 sem token / sem permissão `visualizarTurmas`
  - 200 com `months: []` quando não há snapshots
  - 404 quando snapshot do mês não existe
  - Refresh agrega só HUMAN reviews dos Enrolled, exclui Pending e exclui AI-only
  - `humanReviewRate ≈ 2/3` quando 3 entregaram e 2 foram revisadas humanamente
  - Upsert idempotente: segundo refresh no mesmo mês mantém exatamente 1 linha
  - 400 ao tentar refresh em turma com período encerrado
- [ ] Lint passa (`npm run lint`)
- [ ] Swagger expõe os 3 endpoints em `/api`

## Notas

- **Fix de DI incluído** (`d2a58ee`): `ClassEssayAnalyticsModule` agora importa `UserModule` + `EnvModule` (necessário pelo `PermissionsGuard`). Bug detectado pelos próprios e2e — sem isso, os endpoints estouravam erro de DI no boot.
- **Lock de date contract**: DTOs convertem `Date → ISO string` na camada de service (com `@ApiProperty({ type: String, format: 'date'/'date-time' })`) — pega recomendação não-bloqueante do spec reviewer.
- **`refreshOneMonthInternal` reservado** para Fase B: documentado com JSDoc "called by AnalyticsWorkerService when type='essay'; no permission check — internal use only". Nesta fase, o `refresh()` público chama internamente em loop síncrono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)