### PR TITLE
feat(class-analytics): fase B — integração da fila de redação

### DIFF
--- a/src/modules/prepCourse/class/analytics/class-analytics.module.ts
+++ b/src/modules/prepCourse/class/analytics/class-analytics.module.ts
@@ -2,22 +2,28 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { UserModule } from 'src/modules/user/user.module';
 import { EnvModule } from 'src/shared/modules/env/env.module';
-import { QueueModule } from 'src/shared/modules/queue/queue.module';
 import { HttpServiceAxiosFactory } from 'src/shared/services/axios/http-service-axios.factory';
 import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
 import { ClassModule } from '../class.module';
+import { ClassEssayAnalyticsModule } from '../essay-analytics/class-essay-analytics.module';
 import { ClassAnalyticsController } from './class-analytics.controller';
 import { ClassAnalyticsService } from './class-analytics.service';
 import { AnalyticsCronService } from './crons/analytics-cron.service';
-import { AnalyticsQueueService } from './queue/analytics-queue.service';
+import { AnalyticsQueueModule } from './queue/analytics-queue.module';
 import { AnalyticsWorkerService } from './queue/analytics-worker.service';
 
 @Module({
-  imports: [ClassModule, EnvModule, UserModule, HttpModule, QueueModule],
+  imports: [
+    ClassModule,
+    EnvModule,
+    UserModule,
+    HttpModule,
+    AnalyticsQueueModule,
+    ClassEssayAnalyticsModule,
+  ],
   controllers: [ClassAnalyticsController],
   providers: [
     ClassAnalyticsService,
-    AnalyticsQueueService,
     AnalyticsWorkerService,
     AnalyticsCronService,
     SimuladoHttpService,

--- a/src/modules/prepCourse/class/analytics/crons/analytics-cron.service.spec.ts
+++ b/src/modules/prepCourse/class/analytics/crons/analytics-cron.service.spec.ts
@@ -9,7 +9,10 @@ describe('AnalyticsCronService', () => {
 
   beforeEach(() => {
     classService = { findAllWithActivePeriod: jest.fn() } as any;
-    queue = { enqueue: jest.fn().mockResolvedValue('id'), enqueueMany: jest.fn() } as any;
+    queue = {
+      enqueue: jest.fn().mockResolvedValue('id'),
+      enqueueMany: jest.fn().mockResolvedValue([]),
+    } as any;
     cron = new AnalyticsCronService(classService, queue);
   });
 
@@ -22,7 +25,7 @@ describe('AnalyticsCronService', () => {
       },
     }) as any;
 
-  it('weekly cron enqueues current month for each active class', async () => {
+  it('weekly cron enqueues 2 jobs (simulado+essay) per active class for current month', async () => {
     classService.findAllWithActivePeriod.mockResolvedValue([
       klass('c1', '2026-01-01', '2026-12-31'),
       klass('c2', '2026-01-01', '2026-12-31'),
@@ -30,31 +33,54 @@ describe('AnalyticsCronService', () => {
 
     await cron.weeklyRefreshCurrentMonth();
 
-    expect(queue.enqueue).toHaveBeenCalledTimes(2);
-    // Both classes get the same current month (last month of period or today)
-    const months = queue.enqueue.mock.calls.map((c) => c[1]);
-    expect(new Set(months).size).toBe(1);
+    expect(queue.enqueueMany).toHaveBeenCalledTimes(1);
+    const items = queue.enqueueMany.mock.calls[0][0];
+    expect(items).toHaveLength(4);
+
+    const byClass = items.reduce(
+      (acc: Record<string, string[]>, item) => {
+        acc[item.classId] = (acc[item.classId] ?? []).concat(item.type);
+        return acc;
+      },
+      {},
+    );
+    expect(byClass.c1.sort()).toEqual(['essay', 'simulado']);
+    expect(byClass.c2.sort()).toEqual(['essay', 'simulado']);
+
+    const months = new Set(items.map((i) => i.month));
+    expect(months.size).toBe(1);
   });
 
-  it('monthly cron enqueues all months for each active class', async () => {
+  it('monthly cron enqueues 2 jobs (simulado+essay) per month for each active class', async () => {
     classService.findAllWithActivePeriod.mockResolvedValue([
       klass('c1', '2026-01-01', '2026-03-31'),
     ]);
 
     await cron.monthlyRefreshAllMonths();
 
-    // Period covers Jan, Feb, Mar — 3 months for 1 class
-    expect(queue.enqueue.mock.calls.length).toBeGreaterThanOrEqual(1);
-    const calls = queue.enqueue.mock.calls;
-    expect(calls.every((c) => c[0] === 'c1')).toBe(true);
+    expect(queue.enqueueMany).toHaveBeenCalledTimes(1);
+    const items = queue.enqueueMany.mock.calls[0][0];
+
+    expect(items.every((i) => i.classId === 'c1')).toBe(true);
+
+    const uniqueMonths = new Set(items.map((i) => i.month));
+    expect(items.length).toBe(uniqueMonths.size * 2);
+
+    for (const month of uniqueMonths) {
+      const typesForMonth = items
+        .filter((i) => i.month === month)
+        .map((i) => i.type)
+        .sort();
+      expect(typesForMonth).toEqual(['essay', 'simulado']);
+    }
   });
 
-  it('skips classes without coursePeriod', async () => {
+  it('skips classes without coursePeriod and never calls enqueueMany when nothing remains', async () => {
     classService.findAllWithActivePeriod.mockResolvedValue([
       { id: 'c1', coursePeriod: null } as any,
     ]);
 
     await cron.weeklyRefreshCurrentMonth();
-    expect(queue.enqueue).not.toHaveBeenCalled();
+    expect(queue.enqueueMany).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/prepCourse/class/analytics/crons/analytics-cron.service.ts
+++ b/src/modules/prepCourse/class/analytics/crons/analytics-cron.service.ts
@@ -2,7 +2,12 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { ClassService } from '../../class.service';
 import { listMonthsInPeriod } from '../utils/month-window';
-import { AnalyticsQueueService } from '../queue/analytics-queue.service';
+import {
+  AnalyticsJobType,
+  AnalyticsQueueService,
+} from '../queue/analytics-queue.service';
+
+const JOB_TYPES: AnalyticsJobType[] = ['simulado', 'essay'];
 
 @Injectable()
 export class AnalyticsCronService {
@@ -16,7 +21,11 @@ export class AnalyticsCronService {
   @Cron('0 3 * * 1')
   async weeklyRefreshCurrentMonth() {
     const activeClasses = await this.classService.findAllWithActivePeriod();
-    let count = 0;
+    const items: Array<{
+      classId: string;
+      month: string;
+      type: AnalyticsJobType;
+    }> = [];
     for (const klass of activeClasses) {
       if (!klass.coursePeriod) continue;
       const months = listMonthsInPeriod({
@@ -25,16 +34,26 @@ export class AnalyticsCronService {
       });
       const currentMonth = months[months.length - 1];
       if (!currentMonth) continue;
-      await this.queue.enqueue(klass.id, currentMonth);
-      count++;
+      for (const type of JOB_TYPES) {
+        items.push({ classId: klass.id, month: currentMonth, type });
+      }
     }
-    this.logger.log(`Weekly cron enqueued ${count} jobs (current month only)`);
+    if (items.length > 0) {
+      await this.queue.enqueueMany(items);
+    }
+    this.logger.log(
+      `Weekly cron enqueued ${items.length} jobs (current month, both types)`,
+    );
   }
 
   @Cron('0 3 1 * *')
   async monthlyRefreshAllMonths() {
     const activeClasses = await this.classService.findAllWithActivePeriod();
-    let count = 0;
+    const items: Array<{
+      classId: string;
+      month: string;
+      type: AnalyticsJobType;
+    }> = [];
     for (const klass of activeClasses) {
       if (!klass.coursePeriod) continue;
       const months = listMonthsInPeriod({
@@ -42,12 +61,16 @@ export class AnalyticsCronService {
         endDate: new Date(klass.coursePeriod.endDate),
       });
       for (const month of months) {
-        await this.queue.enqueue(klass.id, month);
-        count++;
+        for (const type of JOB_TYPES) {
+          items.push({ classId: klass.id, month, type });
+        }
       }
     }
+    if (items.length > 0) {
+      await this.queue.enqueueMany(items);
+    }
     this.logger.log(
-      `Monthly cron enqueued ${count} jobs (all months of active classes)`,
+      `Monthly cron enqueued ${items.length} jobs (all months of active classes, both types)`,
     );
   }
 }

--- a/src/modules/prepCourse/class/analytics/queue/analytics-queue.module.ts
+++ b/src/modules/prepCourse/class/analytics/queue/analytics-queue.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { QueueModule } from 'src/shared/modules/queue/queue.module';
+import { AnalyticsQueueService } from './analytics-queue.service';
+
+@Module({
+  imports: [QueueModule],
+  providers: [AnalyticsQueueService],
+  exports: [AnalyticsQueueService],
+})
+export class AnalyticsQueueModule {}

--- a/src/modules/prepCourse/class/analytics/queue/analytics-queue.service.spec.ts
+++ b/src/modules/prepCourse/class/analytics/queue/analytics-queue.service.spec.ts
@@ -13,28 +13,62 @@ describe('AnalyticsQueueService', () => {
     service = new AnalyticsQueueService(producer);
   });
 
-  it('enqueue publishes to ANALYTICS_STREAM with classId+month', async () => {
+  it('enqueue defaults type to simulado when omitted', async () => {
     const id = await service.enqueue('class-1', '2026-05');
     expect(id).toBe('id-1');
     expect(producer.publish).toHaveBeenCalledWith(ANALYTICS_STREAM, {
       classId: 'class-1',
       month: '2026-05',
+      type: 'simulado',
     });
   });
 
-  it('enqueueMany publishes once per item', async () => {
+  it('enqueue publishes essay type when requested', async () => {
+    await service.enqueue('class-1', '2026-05', 'essay');
+    expect(producer.publish).toHaveBeenCalledWith(ANALYTICS_STREAM, {
+      classId: 'class-1',
+      month: '2026-05',
+      type: 'essay',
+    });
+  });
+
+  it('enqueueMany publishes once per item with explicit type', async () => {
     producer.publish
       .mockResolvedValueOnce('a')
       .mockResolvedValueOnce('b')
       .mockResolvedValueOnce('c');
 
     const ids = await service.enqueueMany([
-      { classId: 'c1', month: '2026-01' },
-      { classId: 'c1', month: '2026-02' },
-      { classId: 'c2', month: '2026-03' },
+      { classId: 'c1', month: '2026-01', type: 'simulado' },
+      { classId: 'c1', month: '2026-02', type: 'essay' },
+      { classId: 'c2', month: '2026-03', type: 'essay' },
     ]);
 
     expect(ids).toEqual(['a', 'b', 'c']);
     expect(producer.publish).toHaveBeenCalledTimes(3);
+    expect(producer.publish).toHaveBeenNthCalledWith(1, ANALYTICS_STREAM, {
+      classId: 'c1',
+      month: '2026-01',
+      type: 'simulado',
+    });
+    expect(producer.publish).toHaveBeenNthCalledWith(2, ANALYTICS_STREAM, {
+      classId: 'c1',
+      month: '2026-02',
+      type: 'essay',
+    });
+    expect(producer.publish).toHaveBeenNthCalledWith(3, ANALYTICS_STREAM, {
+      classId: 'c2',
+      month: '2026-03',
+      type: 'essay',
+    });
+  });
+
+  it('enqueueMany defaults missing type to simulado (back-compat)', async () => {
+    await service.enqueueMany([{ classId: 'c1', month: '2026-01' }]);
+    expect(producer.publish).toHaveBeenCalledWith(ANALYTICS_STREAM, {
+      classId: 'c1',
+      month: '2026-01',
+      type: 'simulado',
+    });
   });
 });

--- a/src/modules/prepCourse/class/analytics/queue/analytics-queue.service.ts
+++ b/src/modules/prepCourse/class/analytics/queue/analytics-queue.service.ts
@@ -3,17 +3,25 @@ import { QueueProducer } from '../../../../../shared/modules/queue/queue.produce
 
 export const ANALYTICS_STREAM = 'stream:vcnafacul:analytics-recalc';
 
+export type AnalyticsJobType = 'simulado' | 'essay';
+
 @Injectable()
 export class AnalyticsQueueService {
   constructor(private readonly producer: QueueProducer) {}
 
-  async enqueue(classId: string, month: string): Promise<string> {
-    return this.producer.publish(ANALYTICS_STREAM, { classId, month });
+  async enqueue(
+    classId: string,
+    month: string,
+    type: AnalyticsJobType = 'simulado',
+  ): Promise<string> {
+    return this.producer.publish(ANALYTICS_STREAM, { classId, month, type });
   }
 
   async enqueueMany(
-    items: Array<{ classId: string; month: string }>,
+    items: Array<{ classId: string; month: string; type?: AnalyticsJobType }>,
   ): Promise<string[]> {
-    return Promise.all(items.map((i) => this.enqueue(i.classId, i.month)));
+    return Promise.all(
+      items.map((i) => this.enqueue(i.classId, i.month, i.type)),
+    );
   }
 }

--- a/src/modules/prepCourse/class/analytics/queue/analytics-worker.service.spec.ts
+++ b/src/modules/prepCourse/class/analytics/queue/analytics-worker.service.spec.ts
@@ -1,5 +1,6 @@
 import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
 import { ClassService } from '../../class.service';
+import { ClassEssayAnalyticsService } from '../../essay-analytics/class-essay-analytics.service';
 import { QueueConsumer } from '../../../../../shared/modules/queue/queue.consumer';
 import { AnalyticsWorkerService } from './analytics-worker.service';
 import { StatusApplication } from '../../../studentCourse/enums/stastusApplication';
@@ -8,14 +9,31 @@ describe('AnalyticsWorkerService', () => {
   let consumer: jest.Mocked<QueueConsumer>;
   let classService: jest.Mocked<ClassService>;
   let simuladoHttp: jest.Mocked<SimuladoHttpService>;
+  let essayAnalytics: jest.Mocked<ClassEssayAnalyticsService>;
   let worker: AnalyticsWorkerService;
 
   beforeEach(() => {
     consumer = { register: jest.fn() } as any;
     classService = { findOneByIdForAnalytics: jest.fn() } as any;
     simuladoHttp = { calculateUserGroupAggregate: jest.fn() } as any;
-    worker = new AnalyticsWorkerService(consumer, classService, simuladoHttp);
+    essayAnalytics = { refreshOneMonthInternal: jest.fn() } as any;
+    worker = new AnalyticsWorkerService(
+      consumer,
+      classService,
+      simuladoHttp,
+      essayAnalytics,
+    );
   });
+
+  const activeKlass = (students: any[] = []) =>
+    ({
+      id: 'class-1',
+      coursePeriod: {
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-12-31'),
+      },
+      students,
+    }) as any;
 
   it('registers consumer on init', () => {
     worker.onModuleInit();
@@ -27,22 +45,21 @@ describe('AnalyticsWorkerService', () => {
     );
   });
 
-  it('calls calculate with enrolled userIds only', async () => {
-    classService.findOneByIdForAnalytics.mockResolvedValue({
-      id: 'class-1',
-      coursePeriod: {
-        startDate: new Date('2026-01-01'),
-        endDate: new Date('2026-12-31'),
-      },
-      students: [
+  it('type=simulado calls simuladoHttp with enrolled userIds only', async () => {
+    classService.findOneByIdForAnalytics.mockResolvedValue(
+      activeKlass([
         { userId: 'u1', applicationStatus: StatusApplication.Enrolled },
         { userId: 'u2', applicationStatus: StatusApplication.Rejected },
         { userId: 'u3', applicationStatus: StatusApplication.Enrolled },
-      ],
-    } as any);
+      ]),
+    );
     simuladoHttp.calculateUserGroupAggregate.mockResolvedValue({} as any);
 
-    await worker.handle('msg-1', { classId: 'class-1', month: '2026-05' });
+    await worker.handle('msg-1', {
+      classId: 'class-1',
+      month: '2026-05',
+      type: 'simulado',
+    });
 
     expect(simuladoHttp.calculateUserGroupAggregate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -51,12 +68,62 @@ describe('AnalyticsWorkerService', () => {
         userIds: ['u1', 'u3'],
       }),
     );
+    expect(essayAnalytics.refreshOneMonthInternal).not.toHaveBeenCalled();
+  });
+
+  it('defaults to simulado when type is missing (back-compat)', async () => {
+    classService.findOneByIdForAnalytics.mockResolvedValue(activeKlass([]));
+    simuladoHttp.calculateUserGroupAggregate.mockResolvedValue({} as any);
+
+    await worker.handle('msg-1', { classId: 'class-1', month: '2026-05' });
+
+    expect(simuladoHttp.calculateUserGroupAggregate).toHaveBeenCalled();
+    expect(essayAnalytics.refreshOneMonthInternal).not.toHaveBeenCalled();
+  });
+
+  it('type=essay calls essayAnalytics with enrolled userIds only', async () => {
+    classService.findOneByIdForAnalytics.mockResolvedValue(
+      activeKlass([
+        { userId: 'u1', applicationStatus: StatusApplication.Enrolled },
+        { userId: 'u2', applicationStatus: StatusApplication.UnderReview },
+      ]),
+    );
+    essayAnalytics.refreshOneMonthInternal.mockResolvedValue({} as any);
+
+    await worker.handle('msg-1', {
+      classId: 'class-1',
+      month: '2026-05',
+      type: 'essay',
+    });
+
+    expect(essayAnalytics.refreshOneMonthInternal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classId: 'class-1',
+        month: '2026-05',
+        userIds: ['u1'],
+      }),
+    );
+    expect(simuladoHttp.calculateUserGroupAggregate).not.toHaveBeenCalled();
+  });
+
+  it('unknown type logs warning and dispatches nothing', async () => {
+    classService.findOneByIdForAnalytics.mockResolvedValue(activeKlass([]));
+
+    await worker.handle('msg-1', {
+      classId: 'class-1',
+      month: '2026-05',
+      type: 'mystery',
+    });
+
+    expect(simuladoHttp.calculateUserGroupAggregate).not.toHaveBeenCalled();
+    expect(essayAnalytics.refreshOneMonthInternal).not.toHaveBeenCalled();
   });
 
   it('skips when class not found', async () => {
     classService.findOneByIdForAnalytics.mockResolvedValue(null);
     await worker.handle('m', { classId: 'missing', month: '2026-05' });
     expect(simuladoHttp.calculateUserGroupAggregate).not.toHaveBeenCalled();
+    expect(essayAnalytics.refreshOneMonthInternal).not.toHaveBeenCalled();
   });
 
   it('skips when missing fields', async () => {
@@ -64,19 +131,29 @@ describe('AnalyticsWorkerService', () => {
     expect(classService.findOneByIdForAnalytics).not.toHaveBeenCalled();
   });
 
-  it('propagates error so Valkey can retry', async () => {
-    classService.findOneByIdForAnalytics.mockResolvedValue({
-      id: 'class-1',
-      coursePeriod: {
-        startDate: new Date('2026-01-01'),
-        endDate: new Date('2026-12-31'),
-      },
-      students: [],
-    } as any);
-    simuladoHttp.calculateUserGroupAggregate.mockRejectedValue(new Error('boom'));
+  it('propagates error from simulado handler so queue retries', async () => {
+    classService.findOneByIdForAnalytics.mockResolvedValue(activeKlass([]));
+    simuladoHttp.calculateUserGroupAggregate.mockRejectedValue(
+      new Error('boom'),
+    );
 
     await expect(
       worker.handle('m', { classId: 'class-1', month: '2026-05' }),
     ).rejects.toThrow('boom');
+  });
+
+  it('propagates error from essay handler so queue retries', async () => {
+    classService.findOneByIdForAnalytics.mockResolvedValue(activeKlass([]));
+    essayAnalytics.refreshOneMonthInternal.mockRejectedValue(
+      new Error('essay-boom'),
+    );
+
+    await expect(
+      worker.handle('m', {
+        classId: 'class-1',
+        month: '2026-05',
+        type: 'essay',
+      }),
+    ).rejects.toThrow('essay-boom');
   });
 });

--- a/src/modules/prepCourse/class/analytics/queue/analytics-worker.service.ts
+++ b/src/modules/prepCourse/class/analytics/queue/analytics-worker.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { SimuladoHttpService } from 'src/shared/services/simulado-http.service';
 import { StatusApplication } from '../../../studentCourse/enums/stastusApplication';
 import { ClassService } from '../../class.service';
+import { ClassEssayAnalyticsService } from '../../essay-analytics/class-essay-analytics.service';
 import { computeMonthWindow } from '../utils/month-window';
 import { QueueConsumer } from '../../../../../shared/modules/queue/queue.consumer';
 import { ANALYTICS_STREAM } from './analytics-queue.service';
@@ -14,6 +15,7 @@ export class AnalyticsWorkerService implements OnModuleInit {
     private readonly consumer: QueueConsumer,
     private readonly classService: ClassService,
     private readonly simuladoHttp: SimuladoHttpService,
+    private readonly essayAnalytics: ClassEssayAnalyticsService,
   ) {}
 
   onModuleInit() {
@@ -26,15 +28,19 @@ export class AnalyticsWorkerService implements OnModuleInit {
   }
 
   async handle(_id: string, fields: Record<string, string>) {
-    const { classId, month } = fields;
+    const { classId, month, type = 'simulado' } = fields;
     if (!classId || !month) {
-      this.logger.warn(`Skipping message with missing fields: ${JSON.stringify(fields)}`);
+      this.logger.warn(
+        `Skipping message with missing fields: ${JSON.stringify(fields)}`,
+      );
       return;
     }
 
     const klass = await this.classService.findOneByIdForAnalytics(classId);
     if (!klass?.coursePeriod) {
-      this.logger.warn(`Class ${classId} not found or has no coursePeriod; skipping ${month}`);
+      this.logger.warn(
+        `Class ${classId} not found or has no coursePeriod; skipping ${month}`,
+      );
       return;
     }
 
@@ -49,16 +55,32 @@ export class AnalyticsWorkerService implements OnModuleInit {
       .map((s) => s.userId);
 
     try {
-      await this.simuladoHttp.calculateUserGroupAggregate({
-        groupId: classId,
-        month,
-        monthStart,
-        monthEnd,
-        userIds,
-      });
-      this.logger.log(`Recalculated ${classId} / ${month}`);
+      if (type === 'simulado') {
+        await this.simuladoHttp.calculateUserGroupAggregate({
+          groupId: classId,
+          month,
+          monthStart,
+          monthEnd,
+          userIds,
+        });
+      } else if (type === 'essay') {
+        await this.essayAnalytics.refreshOneMonthInternal({
+          classId,
+          month,
+          monthStart,
+          monthEnd,
+          userIds,
+        });
+      } else {
+        this.logger.warn(`Unknown analytics job type: ${type}`);
+        return;
+      }
+      this.logger.log(`Recalculated ${type} ${classId} / ${month}`);
     } catch (err) {
-      this.logger.error(`Failed to recalc ${classId} / ${month}`, err as Error);
+      this.logger.error(
+        `Failed to recalc ${type} ${classId} / ${month}`,
+        err as Error,
+      );
       throw err;
     }
   }

--- a/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.module.ts
+++ b/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserModule } from 'src/modules/user/user.module';
 import { EnvModule } from 'src/shared/modules/env/env.module';
+import { AnalyticsQueueModule } from '../analytics/queue/analytics-queue.module';
 import { ClassModule } from '../class.module';
 import { ClassEssayAnalyticsController } from './class-essay-analytics.controller';
 import { ClassEssayAnalyticsRepository } from './class-essay-analytics.repository';
@@ -11,6 +12,7 @@ import { ClassEssaySnapshot } from './class-essay-snapshot.entity';
 @Module({
   imports: [
     TypeOrmModule.forFeature([ClassEssaySnapshot]),
+    AnalyticsQueueModule,
     ClassModule,
     UserModule,
     EnvModule,

--- a/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.service.spec.ts
+++ b/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { StatusApplication } from '../../studentCourse/enums/stastusApplication';
+import { AnalyticsQueueService } from '../analytics/queue/analytics-queue.service';
 import { ClassService } from '../class.service';
 import { ClassEssayAnalyticsRepository } from './class-essay-analytics.repository';
 import { ClassEssayAnalyticsService } from './class-essay-analytics.service';
@@ -60,6 +61,7 @@ describe('ClassEssayAnalyticsService', () => {
   let service: ClassEssayAnalyticsService;
   let classService: jest.Mocked<ClassService>;
   let repository: jest.Mocked<ClassEssayAnalyticsRepository>;
+  let analyticsQueue: jest.Mocked<AnalyticsQueueService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -80,6 +82,13 @@ describe('ClassEssayAnalyticsService', () => {
             aggregateMonth: jest.fn(),
           },
         },
+        {
+          provide: AnalyticsQueueService,
+          useValue: {
+            enqueue: jest.fn().mockResolvedValue('id-1'),
+            enqueueMany: jest.fn().mockResolvedValue(['id-1']),
+          },
+        },
       ],
     }).compile();
 
@@ -88,6 +97,9 @@ describe('ClassEssayAnalyticsService', () => {
     repository = module.get(
       ClassEssayAnalyticsRepository,
     ) as jest.Mocked<ClassEssayAnalyticsRepository>;
+    analyticsQueue = module.get(
+      AnalyticsQueueService,
+    ) as jest.Mocked<AnalyticsQueueService>;
   });
 
   // ── listMonths ──────────────────────────────────────────────────────────────
@@ -182,61 +194,50 @@ describe('ClassEssayAnalyticsService', () => {
   // ── refresh ─────────────────────────────────────────────────────────────────
 
   describe('refresh', () => {
-    it('with scope=current invokes aggregateMonth and upsert exactly once', async () => {
+    it('with scope=current enqueues exactly one essay job and never touches the repository', async () => {
       classService.findOneById.mockResolvedValue(makeClass());
-      repository.aggregateMonth.mockResolvedValue({
-        geral: 600,
-        competencias: { c1: 120, c2: 120, c3: 120, c4: 120, c5: 120 },
-        studentsWithAtLeastOneHumanReview: 1,
-        essaysReviewedByHuman: 1,
-        essaysSubmittedTotal: 1,
-        humanReviewRate: 1,
-      });
-      repository.upsert.mockResolvedValue(makeSnap());
 
       const result = await service.refresh('class-1', 'current', 'requester-1');
 
-      expect(repository.aggregateMonth).toHaveBeenCalledTimes(1);
-      expect(repository.upsert).toHaveBeenCalledTimes(1);
+      expect(analyticsQueue.enqueueMany).toHaveBeenCalledTimes(1);
+      const items = analyticsQueue.enqueueMany.mock.calls[0][0];
+      expect(items).toHaveLength(1);
+      expect(items[0].classId).toBe('class-1');
+      expect(items[0].type).toBe('essay');
+
+      expect(repository.aggregateMonth).not.toHaveBeenCalled();
+      expect(repository.upsert).not.toHaveBeenCalled();
+
       expect(result.enqueued).toHaveLength(1);
       expect(result.enqueued[0].classId).toBe('class-1');
       expect(result.enqueued[0].type).toBe('essay');
-      expect(result.estimatedSeconds).toBe(1);
-      const upsertArg = (repository.upsert as jest.Mock).mock.calls[0][0];
-      expect(upsertArg.userIds).toEqual(['user-1']);
-      expect(upsertArg.userIds).not.toContain('user-2');
+      expect(result.estimatedSeconds).toBe(2);
     });
 
-    it('with scope=all invokes upsert >= 1 times all with the same classId', async () => {
+    it('with scope=all enqueues one essay job per month', async () => {
       classService.findOneById.mockResolvedValue(
         makeClass({
           coursePeriodStartDate: new Date('2026-01-01'),
           coursePeriodEndDate: new Date('2026-12-31'),
         }),
       );
-      repository.aggregateMonth.mockResolvedValue({
-        geral: 0,
-        competencias: { c1: 0, c2: 0, c3: 0, c4: 0, c5: 0 },
-        studentsWithAtLeastOneHumanReview: 0,
-        essaysReviewedByHuman: 0,
-        essaysSubmittedTotal: 0,
-        humanReviewRate: 0,
-      });
-      repository.upsert.mockResolvedValue(makeSnap());
 
       const result = await service.refresh('class-1', 'all', 'requester-1');
 
-      expect(repository.upsert).toHaveBeenCalled();
-      const calls = repository.upsert.mock.calls;
-      expect(calls.length).toBeGreaterThanOrEqual(1);
-      expect(
-        calls.every((args) => (args[0] as any).classId === 'class-1'),
-      ).toBe(true);
+      expect(analyticsQueue.enqueueMany).toHaveBeenCalledTimes(1);
+      const items = analyticsQueue.enqueueMany.mock.calls[0][0];
+      expect(items.length).toBeGreaterThanOrEqual(1);
+      expect(items.every((i) => i.classId === 'class-1')).toBe(true);
+      expect(items.every((i) => i.type === 'essay')).toBe(true);
+
+      expect(repository.aggregateMonth).not.toHaveBeenCalled();
+      expect(repository.upsert).not.toHaveBeenCalled();
+
       expect(result.enqueued.every((i) => i.type === 'essay')).toBe(true);
-      expect(result.estimatedSeconds).toBe(result.enqueued.length * 1);
+      expect(result.estimatedSeconds).toBe(result.enqueued.length * 2);
     });
 
-    it('throws BadRequestException when period has ended', async () => {
+    it('throws BadRequestException when period has ended (does not enqueue)', async () => {
       classService.findOneById.mockResolvedValue(
         makeClass({
           coursePeriodStartDate: new Date('2020-01-01'),
@@ -248,11 +249,10 @@ describe('ClassEssayAnalyticsService', () => {
         service.refresh('class-1', 'current', 'requester-1'),
       ).rejects.toThrow(BadRequestException);
 
-      expect(repository.aggregateMonth).not.toHaveBeenCalled();
-      expect(repository.upsert).not.toHaveBeenCalled();
+      expect(analyticsQueue.enqueueMany).not.toHaveBeenCalled();
     });
 
-    it('throws BadRequestException when class has no coursePeriodStartDate', async () => {
+    it('throws BadRequestException when class has no coursePeriodStartDate (does not enqueue)', async () => {
       classService.findOneById.mockResolvedValue(
         makeClass({ coursePeriodStartDate: null }),
       );
@@ -260,13 +260,15 @@ describe('ClassEssayAnalyticsService', () => {
       await expect(
         service.refresh('class-1', 'current', 'requester-1'),
       ).rejects.toThrow(BadRequestException);
+
+      expect(analyticsQueue.enqueueMany).not.toHaveBeenCalled();
     });
   });
 
   // ── refreshOneMonthInternal ─────────────────────────────────────────────────
 
   describe('refreshOneMonthInternal', () => {
-    it('calls aggregateMonth then upsert with the right payload, never touching classService', async () => {
+    it('calls aggregateMonth then upsert with the right payload, never touching classService or queue', async () => {
       const payload = {
         geral: 700,
         competencias: { c1: 140, c2: 140, c3: 140, c4: 140, c5: 140 },
@@ -290,6 +292,7 @@ describe('ClassEssayAnalyticsService', () => {
       });
 
       expect(classService.findOneById).not.toHaveBeenCalled();
+      expect(analyticsQueue.enqueueMany).not.toHaveBeenCalled();
       expect(repository.aggregateMonth).toHaveBeenCalledWith({
         classId: 'class-1',
         monthStart,

--- a/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.service.ts
+++ b/src/modules/prepCourse/class/essay-analytics/class-essay-analytics.service.ts
@@ -4,10 +4,10 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import {
-  computeMonthWindow,
   isActivePeriod,
   listMonthsInPeriod,
 } from '../analytics/utils/month-window';
+import { AnalyticsQueueService } from '../analytics/queue/analytics-queue.service';
 import { ClassService } from '../class.service';
 import { StatusApplication } from '../../studentCourse/enums/stastusApplication';
 import { ClassEssayAnalyticsRepository } from './class-essay-analytics.repository';
@@ -32,6 +32,7 @@ export class ClassEssayAnalyticsService {
   constructor(
     private readonly classService: ClassService,
     private readonly repository: ClassEssayAnalyticsRepository,
+    private readonly analyticsQueue: AnalyticsQueueService,
   ) {}
 
   async listMonths(
@@ -102,29 +103,16 @@ export class ClassEssayAnalyticsService {
     const months =
       scope === 'all' ? allMonths : [allMonths[allMonths.length - 1]];
 
-    const userIds = (klass.students ?? [])
-      .filter((s) => s.status === StatusApplication.Enrolled)
-      .map((s) => s.userId);
-
-    // Phase A: synchronous. Phase B will swap this for queue.enqueueMany.
-    for (const month of months) {
-      const { monthStart, monthEnd } = computeMonthWindow(month, period);
-      await this.refreshOneMonthInternal({
-        classId,
-        month,
-        monthStart,
-        monthEnd,
-        userIds,
-      });
-    }
+    const items = months.map((m) => ({
+      classId,
+      month: m,
+      type: 'essay' as const,
+    }));
+    await this.analyticsQueue.enqueueMany(items);
 
     return {
-      enqueued: months.map((m) => ({
-        classId,
-        month: m,
-        type: 'essay' as const,
-      })),
-      estimatedSeconds: months.length,
+      enqueued: items,
+      estimatedSeconds: months.length * 2,
     };
   }
 

--- a/test/class-essay-analytics.e2e-spec.ts
+++ b/test/class-essay-analytics.e2e-spec.ts
@@ -434,6 +434,26 @@ describe('ClassEssayAnalytics (e2e)', () => {
 
   const currentMonth = () => new Date().toISOString().slice(0, 7);
 
+  /**
+   * Phase B: refresh enqueues; the in-memory worker processes the message on a
+   * future tick. Poll the snapshot row until it appears (or fail after timeout).
+   */
+  const waitForSnapshot = async (
+    classId: string,
+    month: string,
+    timeoutMs = 5000,
+  ): Promise<ClassEssaySnapshot> => {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      const snap = await snapshotRepo.findOne({ where: { classId, month } });
+      if (snap) return snap;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    throw new Error(
+      `Timed out waiting for snapshot ${classId}/${month} after ${timeoutMs}ms`,
+    );
+  };
+
   // ────────────────────────────────────────────────────────────────────────────
   // Scenario 1: 403 without token / 403 without visualizarTurmas
   // ────────────────────────────────────────────────────────────────────────────
@@ -573,7 +593,7 @@ describe('ClassEssayAnalytics (e2e)', () => {
     const ePending = await createReviewedEssay(userIdPending, themeD.id);
     await createReview(ePending.id, ReviewType.HUMAN, 1000);
 
-    // Trigger refresh (synchronous in Phase A)
+    // Trigger refresh (Phase B: enqueues; worker processes async)
     const refreshResp = await request(app.getHttpServer())
       .post(`/class/${classId}/analytics/redacao/refresh`)
       .set({ Authorization: `Bearer ${token}` })
@@ -585,6 +605,9 @@ describe('ClassEssayAnalytics (e2e)', () => {
     const month = refreshResp.body.enqueued[0].month as string;
     expect(month).toMatch(/^\d{4}-\d{2}$/);
     expect(month).toBe(currentMonth());
+
+    // Wait for the in-memory worker to materialize the snapshot
+    await waitForSnapshot(classId, month);
 
     // Fetch the produced snapshot
     const getResp = await request(app.getHttpServer())
@@ -630,19 +653,29 @@ describe('ClassEssayAnalytics (e2e)', () => {
     const e1 = await createReviewedEssay(s1.userId, theme.id);
     await createReview(e1.id, ReviewType.HUMAN, 500);
 
-    // First refresh
-    await request(app.getHttpServer())
-      .post(`/class/${classId}/analytics/redacao/refresh`)
-      .set({ Authorization: `Bearer ${token}` })
-      .expect(202);
-
-    // Second refresh on the same month should not duplicate the row
-    await request(app.getHttpServer())
-      .post(`/class/${classId}/analytics/redacao/refresh`)
-      .set({ Authorization: `Bearer ${token}` })
-      .expect(202);
-
     const month = currentMonth();
+
+    // First refresh — enqueues and worker writes the snapshot
+    await request(app.getHttpServer())
+      .post(`/class/${classId}/analytics/redacao/refresh`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(202);
+    const first = await waitForSnapshot(classId, month);
+
+    // Second refresh on the same month should upsert (not duplicate)
+    await request(app.getHttpServer())
+      .post(`/class/${classId}/analytics/redacao/refresh`)
+      .set({ Authorization: `Bearer ${token}` })
+      .expect(202);
+
+    // Wait until the worker re-runs (generatedAt advances)
+    const startedAt = Date.now();
+    while (Date.now() - startedAt < 5000) {
+      const row = await snapshotRepo.findOne({ where: { classId, month } });
+      if (row && row.generatedAt.getTime() > first.generatedAt.getTime()) break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
     const rows = await snapshotRepo.find({ where: { classId, month } });
     expect(rows).toHaveLength(1);
 


### PR DESCRIPTION
## Resumo

Fase B do roadmap [turma-analytics-redacao](../tree/develop/../docs/turma-analytics-redacao/fase-b-integracao-fila.md): estende a infraestrutura de fila/worker/crons (construída na Fase D de simulado) para também processar jobs de redação.

- `AnalyticsQueueService` agora aceita `type: 'simulado' | 'essay'` no payload; default `'simulado'` preserva back-compat com chamadores existentes
- `AnalyticsWorkerService` despacha por tipo: `simulado` → `simuladoHttp.calculateUserGroupAggregate`, `essay` → `ClassEssayAnalyticsService.refreshOneMonthInternal`
- `AnalyticsCronService` (weekly + monthly) passa a enfileirar 2 jobs por (turma, mês), um de cada tipo
- `ClassEssayAnalyticsService.refresh` agora enfileira (assíncrono, retorna 202 semanticamente) em vez de calcular sincronamente

## Decisões de design

**Extração de `AnalyticsQueueModule`.** Para evitar dependência circular entre `ClassAnalyticsModule` (contém o worker, que injeta `ClassEssayAnalyticsService`) e `ClassEssayAnalyticsModule` (que precisa de `AnalyticsQueueService`), o serviço de fila foi movido para um módulo próprio compartilhado. Os dois módulos de domínio importam apenas o módulo de fila — sem ciclo.

**`type?` opcional em `enqueueMany`.** O plano original exigia `type` obrigatório, mas isso quebraria `ClassAnalyticsService.refresh()` que passa `{ classId, month }` sem `type`. Mantive `type?` opcional com default `'simulado'` no `enqueue` para back-compat sem renomear nada.

## Commits

- `99cfc87` — `feat(class-analytics): support job type in queue payload (simulado|essay)`
- `d0397e1` — `feat(class-analytics): worker routes by job type (simulado|essay)`
- `7eb91df` — `feat(class-analytics): crons enqueue both simulado and essay jobs`
- `5a902a0` — `refactor(class-essay-analytics): refresh enqueues instead of running synchronously`

## Test Plan

- [x] Unit tests passam (45 testes em queue/worker/crons/essay/simulado/month-window)
- [x] `npx tsc --noEmit` compila sem erros
- [x] E2E `class-essay-analytics.e2e-spec.ts` atualizado com `waitForSnapshot` polling helper para acomodar refresh assíncrono
- [ ] Smoke local com Docker MySQL+Redis bloqueado por falta de espaço em disco no Docker; CI valida o e2e completo
- [ ] Após merge: validar com Fase C que o frontend lida com o 202 (refresh retorna `enqueued + estimatedSeconds`, sem snapshot imediato)

## Próximos passos

Fase C (frontend) pode prosseguir em paralelo — o contrato dos endpoints não muda, apenas a semântica do `POST /refresh` passa de síncrono para assíncrono.