### PR TITLE
fix(student-course): remove Content-Type invalido antes de res.json() em getDocument/getProfilePhoto

### DIFF
--- a/src/modules/prepCourse/studentCourse/student-course.controller.ts
+++ b/src/modules/prepCourse/studentCourse/student-course.controller.ts
@@ -176,11 +176,6 @@ export class StudentCourseController {
   ) {
     const { buffer, contentType } = await this.service.getDocument(fileKey);
 
-    res.set({
-      'Content-Type': contentType,
-      'Content-Disposition': `inline; filename="${fileKey}"`,
-    });
-
     return res.status(HttpStatus.OK).json({
       buffer: buffer,
       contentType,
@@ -203,11 +198,6 @@ export class StudentCourseController {
     @Res() res: Response,
   ) {
     const { buffer, contentType } = await this.service.getProfilePhoto(fileKey);
-
-    res.set({
-      'Content-Type': contentType,
-      'Content-Disposition': `inline; filename="${fileKey}"`,
-    });
 
     return res.status(HttpStatus.OK).json({
       buffer: buffer,


### PR DESCRIPTION
## Summary
- Remove o `res.set({ 'Content-Type': ... })` antes do `res.json(...)` nos endpoints `GET /student-course/document/:fileKey` e `GET /student-course/profile-photo/:fileKey`.
- Quando o mime do objeto no R2 esta vazio/invalido, o Express.setCharset estoura com `TypeError: invalid media type` ao tentar appendar `charset=utf-8` — derrubando a request com 500.
- O `res.set` era inutil mesmo: `.json()` sempre força `Content-Type: application/json`, entao o header da imagem ja era sobrescrito. O frontend ja le `contentType` do corpo JSON.

## Erro em producao corrigido
```
TypeError: invalid media type
  at Object.parse (content-type/index.js:126:11)
  at setCharset (express/lib/utils.js:252:28)
  at ServerResponse.send (express/lib/response.js:174:32)
  at ServerResponse.json (express/lib/response.js:278:15)
  at StudentCourseController.getProfilePhoto (student-course.controller.ts:206:38)
```

## Test plan
- [ ] Subir em homologacao
- [ ] Limpar cache Redis das chaves `profile:photo:*` e `document:*` antes de testar (TTL de 7 dias pode segurar payloads quebrados)
- [ ] Reenviar foto de carteirinha por `PATCH /student-course/declaration-photo` com um aluno em `CalledForEnrollment`
- [ ] Chamar `GET /student-course/profile-photo/:fileKey` — deve retornar 200 com `{ buffer, contentType }` em JSON
- [ ] Chamar `GET /student-course/document/:fileKey` em um doc ja existente — deve retornar 200 sem 500
- [ ] Confirmar no front que a foto/documento renderizam (usam `data:\${contentType};base64,\${buffer}`)

## Rollback
Mudanca minima (10 linhas removidas, sem migration, sem nova dependencia). Reverter o commit volta ao comportamento atual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)