### PR TITLE
fix(student-course): corrige cache poisoning em updateProfilePhotoByStudent

### DIFF
--- a/src/modules/prepCourse/studentCourse/student-course.service.ts
+++ b/src/modules/prepCourse/studentCourse/student-course.service.ts
@@ -256,7 +256,7 @@ export class StudentCourseService extends BaseService<StudentCourse> {
     );
     await this.cache.set(
       `profile:photo:${fileKey}`,
-      file,
+      { buffer: file.buffer.toString('base64'), contentType: file.mimetype },
       60 * 60 * 24 * 1000 * 7,
     );
     student.photo = fileKey;


### PR DESCRIPTION
## Summary
Segue o fix do bug do `atob: not correctly encoded` que apareceu em homol depois do merge do #484.

O `updateProfilePhotoByStudent` (PATCH `/student-course/profile-image`, fluxo admin) chamava `cache.set` com o objeto Multer File cru. Ao serializar via KeyV/Redis (JSON.stringify), o Buffer vira `{ type: 'Buffer', data: [...] }` e o objeto nao tem `contentType` (Multer usa `mimetype`).

Quando o front busca depois via `GET /student-course/profile-photo/:fileKey`, o `getProfilePhoto` faz `cache.wrap` na mesma chave esperando `{ buffer: base64, contentType }`, mas pega a shape do Multer envenenada. A response sai com `buffer` como objeto, o `atob(response.buffer)` coage pra `"[object Object]"` e estoura `InvalidCharacterError`.

## O fix
Salva no cache ja na shape correta esperada por `getProfilePhoto`:
```ts
await this.cache.set(
  `profile:photo:${fileKey}`,
  { buffer: file.buffer.toString('base64'), contentType: file.mimetype },
  60 * 60 * 24 * 1000 * 7,
);
```

## Por que so apareceu agora
`submitPhoto` (fluxo do estudante na declaracao) nao toca no cache. So o `updateProfilePhotoByStudent` (admin) envenena. Logo:
- Estudante enviando foto pelo fluxo de declaracao → cache populado naturalmente no primeiro GET → funcionava.
- Admin atualizando foto via `/profile-image` → cache envenenado → atob quebra.

## Test plan
- [ ] **Limpar chaves `profile:photo:*` no Redis de homol** antes de testar (TTL 7d ainda segura entradas envenenadas)
- [ ] Logar como admin com permissao `gerenciarEstudantes`
- [ ] Atualizar foto de um estudante via `PATCH /student-course/profile-image`
- [ ] Chamar `GET /student-course/profile-photo/:fileKey` com a nova fileKey
- [ ] Verificar que a response tem `buffer` como string base64 (nao objeto) e `contentType: image/...`
- [ ] Confirmar no front que a foto renderiza sem erro de `atob`

## Rollback
Mudanca minima (1 linha). Reverter o commit volta ao comportamento anterior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)