### PR TITLE
feat(simulado): forward pagination params from gateway to ms-simulado

### DIFF
--- a/src/modules/simulado/simulado.controller.ts
+++ b/src/modules/simulado/simulado.controller.ts
@@ -17,6 +17,7 @@ import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
 import { PermissionsGuard } from 'src/shared/guards/permission.guard';
 import { Permissions } from '../role/role.entity';
 import { User } from '../user/user.entity';
+import { GetAllDtoInput } from 'src/shared/dtos/get-all.dto.input';
 import { AnswerSimulado } from './dtos/answer-simulado.dto.input';
 import { AvailableSimuladoDTOoutput } from './dtos/available-simulado.dto.output';
 import { CreateSimuladoDTOInput } from './dtos/create-simulado.dto.input';
@@ -51,8 +52,8 @@ export class SimuladoController {
     type: SimuladoDTO,
     isArray: true,
   })
-  async getAdd(): Promise<SimuladoDTO[]> {
-    return await this.simuladoService.getAll();
+  async getAdd(@Query() query: GetAllDtoInput): Promise<SimuladoDTO[]> {
+    return await this.simuladoService.getAll(query.page, query.limit);
   }
 
   @Get('tipos')

--- a/src/modules/simulado/simulado.service.ts
+++ b/src/modules/simulado/simulado.service.ts
@@ -34,8 +34,8 @@ export class SimuladoService {
     return await this.axios.post<SimuladoDTO>('v1/simulado', dto);
   }
 
-  async getAll() {
-    return await this.axios.get<SimuladoDTO[]>('v1/simulado');
+  async getAll(page: number = 1, limit: number = 500) {
+    return await this.axios.get<SimuladoDTO[]>(`v1/simulado?page=${page}&limit=${limit}`);
   }
 
   async getTipos() {


### PR DESCRIPTION
## Summary

- O endpoint `GET /mssimulado/simulado` não aceitava nem repassava `page`/`limit` ao ms-simulado, ignorando os parâmetros enviados pelo frontend
- Adicionado `GetAllDtoInput` como `@Query()` no controller para capturar os parâmetros
- O service agora constrói a URL com `page` e `limit`, com default de 500 por página

## Test Plan

- [ ] `GET /mssimulado/simulado` sem parâmetros retorna até 500 simulados
- [ ] `GET /mssimulado/simulado?page=1&limit=100` respeita o limit enviado
- [ ] Tela de gestão de simulados (`/dashSimulado`) carrega todos os simulados corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)