### PR TITLE
feat(class): expose partnerId in get-class-by-id response

### DIFF
--- a/src/modules/prepCourse/class/class.repository.ts
+++ b/src/modules/prepCourse/class/class.repository.ts
@@ -76,6 +76,8 @@ export class ClassRepository extends BaseRepository<Class> {
       ])
       .leftJoinAndSelect('entity.admins', 'admins')
       .leftJoinAndSelect('entity.coursePeriod', 'course_period')
+      .leftJoin('entity.partnerPrepCourse', 'partner_prep_course')
+      .addSelect(['partner_prep_course.id'])
       .where('entity.id = :id', { id })
       .getOne();
   }

--- a/src/modules/prepCourse/class/class.service.ts
+++ b/src/modules/prepCourse/class/class.service.ts
@@ -131,6 +131,7 @@ export class ClassService extends BaseService<Class> {
         });
         const result = {
           ...classEntity,
+          partnerId: classEntity.partnerPrepCourse?.id || '',
           coursePeriodId: classEntity.coursePeriod?.id || '',
           coursePeriodName: classEntity.coursePeriod?.name || '',
           coursePeriodYear: classEntity.coursePeriod?.year || 0,

--- a/src/modules/prepCourse/class/dtos/get-class-by-id.dto.output.ts
+++ b/src/modules/prepCourse/class/dtos/get-class-by-id.dto.output.ts
@@ -5,6 +5,7 @@ export class GetClassByIdDtoOutput {
   id: string;
   name: string;
   description?: string;
+  partnerId: string;
   coursePeriodId: string;
   coursePeriodName: string;
   coursePeriodYear: number;


### PR DESCRIPTION
## Summary

- Adiciona join com `partnerPrepCourse` na query `findOneById` do repositório de turmas
- Mapeia `partnerId` no DTO de output e no service
- Necessário para que o frontend possa buscar o logo do cursinho na tela de turmas

## Test plan

- [ ] Verificar que `GET /class/:id` retorna `partnerId` corretamente
- [ ] Confirmar que o campo não quebra requisições existentes (campo adicional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)