### PR TITLE
fix(queue): prevent event-loop spin when registrations is empty

### DIFF
--- a/src/shared/modules/queue/valkey/valkey-queue.consumer.ts
+++ b/src/shared/modules/queue/valkey/valkey-queue.consumer.ts
@@ -60,6 +60,10 @@ export class ValkeyQueueConsumer
 
   private async poll() {
     while (this.running) {
+      if (this.registrations.length === 0) {
+        await new Promise((r) => setTimeout(r, 100));
+        continue;
+      }
       for (const reg of this.registrations) {
         await this.readAndProcess(reg);
         await this.reclaimStale(reg);


### PR DESCRIPTION
## Summary
- `ValkeyQueueConsumer.poll()` entrava em spin loop infinito com 100% de CPU quando o array `registrations` estava vazio no startup
- O loop `while(this.running)` sem nenhum `await` bloqueava o event loop do Node.js, impedindo que o `app.listen()` fosse executado
- Fix: adiciona `await new Promise(r => setTimeout(r, 100))` + `continue` quando não há registrations, cedendo o event loop até que os handlers sejam registrados

## Root cause
O `ValkeyQueueConsumer` é inicializado antes do `AnalyticsWorkerService` (ordem de dependências do NestJS). Quando `onModuleInit` inicia o `poll()`, o array `registrations` ainda está vazio. Sem nenhum `await` dentro do `for`, o `while` girava indefinidamente bloqueando o event loop.

## Test plan
- [ ] Reiniciar o container da API e verificar que loga "Nest application successfully started"
- [ ] Verificar que o CPU não sobe para 100% no startup
- [ ] Verificar que o consumer processa mensagens normalmente após startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)