### PR TITLE
[Etapa 2 · Card 04] Migration: preservar visualizar_provas antes de dropar criar_simulado

### DIFF
--- a/src/db/migrations/1783296001000-preserve_visualizar_provas_from_criar_simulado.ts
+++ b/src/db/migrations/1783296001000-preserve_visualizar_provas_from_criar_simulado.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PreserveVisualizarProvasFromCriarSimulado1783296001000
+  implements MigrationInterface
+{
+  name = 'PreserveVisualizarProvasFromCriarSimulado1783296001000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE \`roles\`
+       SET \`visualizar_provas\` = 1
+       WHERE \`criar_simulado\` = 1
+         AND \`visualizar_provas\` = 0`,
+    );
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // intentionally empty — rollback not safe nor required
+  }
+}


### PR DESCRIPTION
## Resumo

- Adiciona migration de dados (`1783225907857-preserve_visualizar_provas_from_criar_simulado.ts`) criada manualmente — TypeORM `migration:generate` não detecta DML
- `up()`: `UPDATE roles SET visualizar_provas = 1 WHERE criar_simulado = 1 AND visualizar_provas = 0` — aditiva, não destrutiva
- `down()`: vazio intencional — rollback não é seguro nem necessário

## Por que este card existe

A permissão `criar_simulado` no banco tinha label enganoso "Visualizar Simulados" na UI. Antes de dropar a coluna (Card 05), precisamos garantir que nenhuma role perde acesso — quem tinha `criar_simulado = 1` recebe `visualizar_provas = 1`.

## Dependências

**Ordem de merge e deploy:** **Card 04** → Card 05

- Bloqueia: Card 05 (DROP COLUMN `criar_simulado`)
- Esta migration precisa rodar em prod **antes** do deploy do Card 05

## Plano de teste

- [ ] Rodar query prévia: `SELECT COUNT(*) FROM roles WHERE criar_simulado = 1 AND visualizar_provas = 0`
- [ ] Executar migration: `npm run migration:run`
- [ ] Confirmar: `SELECT COUNT(*) FROM roles WHERE criar_simulado = 1 AND visualizar_provas = 0` → 0
- [ ] `npm run build` passa

🤖 Generated with [Claude Code](https://claude.com/claude-code)