### PR TITLE
[Etapa 2 · Card 05] Backend cleanup: remover criarSimulado e dropar coluna criar_simulado

### DIFF
--- a/src/db/migrations/1783225907857-preserve_visualizar_provas_from_criar_simulado.ts
+++ b/src/db/migrations/1783225907857-preserve_visualizar_provas_from_criar_simulado.ts
@@ -1,9 +1,9 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class PreserveVisualizarProvasFromCriarSimulado1783296001000
+export class PreserveVisualizarProvasFromCriarSimulado1783225907857
   implements MigrationInterface
 {
-  name = 'PreserveVisualizarProvasFromCriarSimulado1783296001000';
+  name = 'PreserveVisualizarProvasFromCriarSimulado1783225907857';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/src/db/migrations/1783225907858-drop_criar_simulado.ts
+++ b/src/db/migrations/1783225907858-drop_criar_simulado.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class DropCriarSimulado1783225907858 implements MigrationInterface {
+    name = 'DropCriarSimulado1783225907858'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`roles\` DROP COLUMN \`criar_simulado\``);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`roles\` ADD \`criar_simulado\` tinyint NOT NULL DEFAULT '0'`);
+    }
+
+}

--- a/src/db/migrations/1783296001000-preserve_visualizar_provas_from_criar_simulado.ts
+++ b/src/db/migrations/1783296001000-preserve_visualizar_provas_from_criar_simulado.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PreserveVisualizarProvasFromCriarSimulado1783296001000
+  implements MigrationInterface
+{
+  name = 'PreserveVisualizarProvasFromCriarSimulado1783296001000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE \`roles\`
+       SET \`visualizar_provas\` = 1
+       WHERE \`criar_simulado\` = 1
+         AND \`visualizar_provas\` = 0`,
+    );
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // intentionally empty — rollback not safe nor required
+  }
+}

--- a/src/db/seeds/1-role.seed.ts
+++ b/src/db/seeds/1-role.seed.ts
@@ -8,7 +8,6 @@ const RoleData = [
     name: 'admin',
     validarCursinho: true,
     alterarPermissao: true,
-    criarSimulado: true,
   },
 ];
 

--- a/src/db/seeds/2-role-update-admin.seed.ts
+++ b/src/db/seeds/2-role-update-admin.seed.ts
@@ -23,7 +23,6 @@ export class RoleUpdateAdminSeedService {
       await this.roleRepository.updateRole('admin', {
         validarCursinho: true,
         alterarPermissao: true,
-        criarSimulado: true,
         criarQuestao: true,
         visualizarQuestao: true,
         validarQuestao: true,

--- a/src/modules/role/dto/create-role.dto.ts
+++ b/src/modules/role/dto/create-role.dto.ts
@@ -20,9 +20,6 @@ export class CreateRoleDtoInput {
   alterarPermissao: boolean;
 
   @IsBoolean()
-  criarSimulado: boolean;
-
-  @IsBoolean()
   visualizarQuestao: boolean;
 
   @IsBoolean()

--- a/src/modules/role/permissions/permission-field-map.ts
+++ b/src/modules/role/permissions/permission-field-map.ts
@@ -3,7 +3,6 @@ import { Permissions } from './permissions';
 export const PERMISSION_FIELD_MAP: Record<Permissions, string> = {
   [Permissions.validarCursinho]: 'validarCursinho',
   [Permissions.alterarPermissao]: 'alterarPermissao',
-  [Permissions.criarSimulado]: 'criarSimulado',
   [Permissions.criarQuestao]: 'criarQuestao',
   [Permissions.visualizarQuestao]: 'visualizarQuestao',
   [Permissions.validarQuestao]: 'validarQuestao',

--- a/src/modules/role/permissions/permission-hierarchy.ts
+++ b/src/modules/role/permissions/permission-hierarchy.ts
@@ -155,17 +155,6 @@ export const PERMISSION_HIERARCHY: PermissionGroup[] = [
     ],
   },
   {
-    key: 'simulado',
-    label: 'Simulado',
-    permissions: [
-      {
-        key: Permissions.criarSimulado,
-        label: 'Visualizar simulado',
-        type: PermissionType.project,
-      },
-    ],
-  },
-  {
     key: 'noticias',
     label: 'Notícias',
     permissions: [

--- a/src/modules/role/permissions/permissions.ts
+++ b/src/modules/role/permissions/permissions.ts
@@ -1,7 +1,6 @@
 export enum Permissions {
   validarCursinho = 'validar_cursinho',
   alterarPermissao = 'alterar_permissao',
-  criarSimulado = 'criar_simulado',
   criarQuestao = 'criar_questao',
   visualizarQuestao = 'visualizar_questao',
   validarQuestao = 'validar_questao',

--- a/src/modules/role/role.entity.ts
+++ b/src/modules/role/role.entity.ts
@@ -18,9 +18,6 @@ export class Role extends BaseEntity {
   @Column({ name: Permissions.alterarPermissao, default: false })
   alterarPermissao: boolean;
 
-  @Column({ name: Permissions.criarSimulado, default: false })
-  criarSimulado: boolean;
-
   @Column({ name: Permissions.criarQuestao, default: false })
   criarQuestao: boolean;
 

--- a/src/modules/role/role.service.ts
+++ b/src/modules/role/role.service.ts
@@ -65,8 +65,6 @@ export class RoleService extends BaseService<Role> {
     const resolved = resolveImpliedPermissions({
       [Permissions.validarCursinho]:
         roleBase?.validarCursinho || roleDto.validarCursinho,
-      [Permissions.criarSimulado]:
-        roleBase?.criarSimulado || roleDto.criarSimulado,
       [Permissions.criarQuestao]:
         roleBase?.criarQuestao || roleDto.criarQuestao,
       [Permissions.validarQuestao]:
@@ -146,7 +144,6 @@ export class RoleService extends BaseService<Role> {
 
     const resolved = resolveImpliedPermissions({
       [Permissions.validarCursinho]: roleDto.validarCursinho,
-      [Permissions.criarSimulado]: roleDto.criarSimulado,
       [Permissions.criarQuestao]: roleDto.criarQuestao,
       [Permissions.validarQuestao]: roleDto.validarQuestao,
       [Permissions.visualizarQuestao]: roleDto.visualizarQuestao,
@@ -197,7 +194,6 @@ export class RoleService extends BaseService<Role> {
     if (role.children?.length > 0) {
       const BASE_PERMISSIONS: Permissions[] = [
         Permissions.validarCursinho,
-        Permissions.criarSimulado,
         Permissions.criarQuestao,
         Permissions.validarQuestao,
         Permissions.visualizarQuestao,

--- a/src/modules/simulado/dtos/create-simulado.dto.input.ts
+++ b/src/modules/simulado/dtos/create-simulado.dto.input.ts
@@ -1,8 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
-
-export class CreateSimuladoDTOInput {
-  @ApiProperty()
-  @IsString()
-  tipoId: string;
-}

--- a/src/modules/simulado/simulado.controller.ts
+++ b/src/modules/simulado/simulado.controller.ts
@@ -20,7 +20,6 @@ import { User } from '../user/user.entity';
 import { GetAllDtoInput } from 'src/shared/dtos/get-all.dto.input';
 import { AnswerSimulado } from './dtos/answer-simulado.dto.input';
 import { AvailableSimuladoDTOoutput } from './dtos/available-simulado.dto.output';
-import { CreateSimuladoDTOInput } from './dtos/create-simulado.dto.input';
 import { ReportDTO } from './dtos/report.dto.input';
 import { SimuladoAnswerDTO } from './dtos/simulado-answer.dto.output';
 import { SimuladoDTO } from './dtos/simulado.dto.output';
@@ -30,19 +29,6 @@ import { SimuladoService } from './simulado.service';
 @Controller('mssimulado/simulado')
 export class SimuladoController {
   constructor(private readonly simuladoService: SimuladoService) {}
-
-  @Post()
-  @ApiResponse({
-    status: 200,
-    description: 'cria simulado',
-    type: SimuladoDTO,
-    isArray: false,
-  })
-  @UseGuards(PermissionsGuard)
-  @SetMetadata(PermissionsGuard.name, Permissions.criarSimulado)
-  async create(@Body() dto: CreateSimuladoDTOInput): Promise<SimuladoDTO> {
-    return await this.simuladoService.create(dto);
-  }
 
   @Get()
   @ApiResponse({
@@ -133,7 +119,7 @@ export class SimuladoController {
       },
     },
   })
-  @SetMetadata(PermissionsGuard.name, Permissions.criarSimulado)
+  @SetMetadata(PermissionsGuard.name, Permissions.cadastrarProvas)
   public async delete(@Param('id') id: string): Promise<void> {
     await this.simuladoService.delete(id);
   }

--- a/src/modules/simulado/simulado.service.ts
+++ b/src/modules/simulado/simulado.service.ts
@@ -8,7 +8,6 @@ import {
 import { AuditLogService } from '../audit-log/audit-log.service';
 import { AnswerSimulado } from './dtos/answer-simulado.dto.input';
 import { AvailableSimuladoDTOoutput } from './dtos/available-simulado.dto.output';
-import { CreateSimuladoDTOInput } from './dtos/create-simulado.dto.input';
 import { ReportDTO } from './dtos/report.dto.input';
 import { SimuladoDTO } from './dtos/simulado.dto.output';
 import { CategoriaDTO } from './dtos/categoria.dto.output';
@@ -30,12 +29,10 @@ export class SimuladoService {
     );
   }
 
-  async create(dto: CreateSimuladoDTOInput) {
-    return await this.axios.post<SimuladoDTO>('v1/simulado', dto);
-  }
-
   async getAll(page: number = 1, limit: number = 500) {
-    return await this.axios.get<SimuladoDTO[]>(`v1/simulado?page=${page}&limit=${limit}`);
+    return await this.axios.get<SimuladoDTO[]>(
+      `v1/simulado?page=${page}&limit=${limit}`,
+    );
   }
 
   async getCategorias() {

--- a/test/course-period.e2e-spec.ts
+++ b/test/course-period.e2e-spec.ts
@@ -101,7 +101,6 @@ describe('CoursePeriod (e2e)', () => {
       base: false,
       validarCursinho: false,
       alterarPermissao: false,
-      criarSimulado: false,
       visualizarQuestao: false,
       criarQuestao: false,
       validarQuestao: false,

--- a/test/role.e2e-spec.ts
+++ b/test/role.e2e-spec.ts
@@ -61,7 +61,6 @@ describe('Role e2e', () => {
         base: true,
         validarCursinho: true,
         alterarPermissao: false,
-        criarSimulado: true,
         visualizarQuestao: true,
         criarQuestao: false,
         validarQuestao: false,
@@ -100,7 +99,6 @@ describe('Role e2e', () => {
       expect(baseRole.name).toBe(baseRoleData.name);
       expect(baseRole.base).toBe(true);
       expect(baseRole.validarCursinho).toBe(true);
-      expect(baseRole.criarSimulado).toBe(true);
       expect(baseRole.uploadNews).toBe(true);
       expect(baseRole.gerenciarProcessoSeletivo).toBe(true);
       expect(baseRole.gerenciarTurmas).toBe(true);
@@ -112,7 +110,6 @@ describe('Role e2e', () => {
         roleBase: baseRole.id,
         validarCursinho: false, // This should be inherited from base role
         alterarPermissao: false,
-        criarSimulado: false, // This should be inherited from base role
         visualizarQuestao: false,
         criarQuestao: true, // New permission not in base
         validarQuestao: false,
@@ -154,7 +151,6 @@ describe('Role e2e', () => {
 
       // Verify inheritance: child role should inherit permissions from base role
       expect(childRole.validarCursinho).toBe(true); // Inherited from base
-      expect(childRole.criarSimulado).toBe(true); // Inherited from base
       expect(childRole.uploadNews).toBe(true); // Inherited from base
       expect(childRole.gerenciarProcessoSeletivo).toBe(false); // It is not a base permission
       expect(childRole.gerenciarTurmas).toBe(false); // It is not a base permission
@@ -171,7 +167,6 @@ describe('Role e2e', () => {
         base: true,
         validarCursinho: false, // Changed from true to false
         alterarPermissao: true, // New permission
-        criarSimulado: true, // Keep same
         visualizarQuestao: true, // New permission
         criarQuestao: true, // New permission
         validarQuestao: true, // New permission
@@ -247,7 +242,6 @@ describe('Role e2e', () => {
         base: true,
         validarCursinho: false,
         alterarPermissao: false,
-        criarSimulado: false,
         visualizarQuestao: false,
         criarQuestao: false,
         validarQuestao: false,
@@ -290,7 +284,6 @@ describe('Role e2e', () => {
         roleBase: baseRole.id,
         validarCursinho: false,
         alterarPermissao: false,
-        criarSimulado: false,
         visualizarQuestao: false,
         criarQuestao: true, // This should automatically enable visualizarQuestao
         validarQuestao: false,


### PR DESCRIPTION
## Resumo

- Remove `criarSimulado` / `criar_simulado` de: enum `Permissions`, `role.entity.ts`, `CreateRoleDtoInput`, `permission-field-map.ts`, `permission-hierarchy.ts`, `role.service.ts` (3 refs), seeds (2 arquivos), e2e tests (2 arquivos)
- Remove endpoint legado `POST /mssimulado/simulado` (zero callers no frontend confirmado via grep)
- Migra guard do `DELETE /mssimulado/simulado/:id` para `Permissions.cadastrarProvas`
- Deleta `create-simulado.dto.input.ts` e o método `create()` no `simulado.service.ts` (órfãos)
- Inclui migration `1783225907858-drop_criar_simulado.ts` — `ALTER TABLE roles DROP COLUMN criar_simulado`

## Dependências

**Ordem de merge e deploy:** Card 04 → **Card 05** → Card 06 (frontend)

- **⚠️ Requer** que a migration do Card 04 (#495) tenha rodado em prod antes do deploy deste card
- Bloqueia: Card 06 frontend cleanup

## Plano de teste

- [ ] `grep -rn "criarSimulado\|criar_simulado" src/ --include="*.ts" | grep -v migrations/` → zero
- [ ] `npm run build` passa
- [ ] Painel de roles não exibe mais opção "Visualizar Simulados"
- [ ] `DELETE /mssimulado/simulado/:id` exige permissão `cadastrarProvas`

🤖 Generated with [Claude Code](https://claude.com/claude-code)