### PR TITLE
feat(scripts): deletar roles sem nenhuma permissão

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "migration:generate": "npm run typeorm migration:generate -n",
     "migration:run": "npm run typeorm -- migration:run",
     "migration:revert": "npm run typeorm -- migration:revert",
-    "create-admin-user": "node --require ts-node/register scripts/create-admin-user.ts"
+    "create-admin-user": "node --require ts-node/register scripts/create-admin-user.ts",
+    "roles:cleanup:permissions": "node --require ts-node/register scripts/delete-roles-without-permissions.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",

--- a/scripts/delete-roles-without-permissions.ts
+++ b/scripts/delete-roles-without-permissions.ts
@@ -1,0 +1,185 @@
+import 'dotenv/config';
+import * as fs from 'fs';
+import * as readline from 'readline';
+import { DataSource } from 'typeorm';
+import { Role } from '../src/modules/role/role.entity';
+import { User } from '../src/modules/user/user.entity';
+import { Permissions } from '../src/modules/role/permissions/permissions';
+
+/**
+ * Deleta roles "inúteis": aquelas em que TODAS as colunas de permissão são
+ * false (equivalentes à role "aluno"), criadas como teste na fase beta.
+ *
+ * Uso:
+ *   node --require ts-node/register scripts/delete-roles-without-permissions.ts            # dry-run (só lista)
+ *   node --require ts-node/register scripts/delete-roles-without-permissions.ts --apply    # lista, pede confirmação e deleta
+ *   ... --apply --yes                                                                      # pula a confirmação interativa
+ *
+ * Config lida de .env ou variáveis de ambiente:
+ *   MY_HOST, MY_PORT, MY_USER, MY_PASSWORD, MY_DB_NAME
+ */
+
+// Nomes das propriedades de permissão na entity Role (chaves do enum Permissions).
+// Enum de string não gera reverse mapping, então Object.keys devolve exatamente
+// as propriedades da entity (validarCursinho, alterarPermissao, ...).
+const PERMISSION_PROPS = Object.keys(Permissions) as (keyof Role)[];
+
+// Roles que nunca devem ser deletadas, mesmo sem permissões.
+const PROTECTED_ROLE_NAMES = new Set(['aluno', 'admin']);
+
+interface Args {
+  apply: boolean;
+  yes: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  return {
+    apply: argv.includes('--apply'),
+    yes: argv.includes('--yes'),
+  };
+}
+
+function hasAllPermissionsFalse(role: Role): boolean {
+  return PERMISSION_PROPS.every((prop) => role[prop] === false);
+}
+
+function confirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(/^s|^y/i.test(answer.trim()));
+    });
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const ds = new DataSource({
+    type: 'mysql',
+    host: process.env.MY_HOST,
+    port: Number(process.env.MY_PORT),
+    username: process.env.MY_USER,
+    password: process.env.MY_PASSWORD,
+    database: process.env.MY_DB_NAME,
+    entities: [__dirname + '/../src/**/*.entity.{js,ts}'],
+    synchronize: false,
+    timezone: 'Z',
+  });
+
+  await ds.initialize();
+  try {
+    const roleRepo = ds.getRepository(Role);
+
+    // Carrega todas as roles com as relações necessárias para as salvaguardas.
+    // A tabela roles é pequena (dezenas de linhas), então isso é barato.
+    const roles = await roleRepo.find({
+      relations: { partnerPrepCourse: true, children: true },
+    });
+
+    // Contagem de usuários por role (sem carregar as linhas de users).
+    const userCounts = await ds
+      .createQueryBuilder()
+      .select('u.roleId', 'roleId')
+      .addSelect('COUNT(*)', 'cnt')
+      .from(User, 'u')
+      .groupBy('u.roleId')
+      .getRawMany<{ roleId: string; cnt: string }>();
+    const usersByRole = new Map(
+      userCounts.map((c) => [c.roleId, Number(c.cnt)]),
+    );
+
+    // Candidatas: todas as permissões false.
+    const candidates = roles.filter(hasAllPermissionsFalse);
+
+    const eligible: Role[] = [];
+    const skipped: { role: Role; reason: string }[] = [];
+
+    for (const role of candidates) {
+      const users = usersByRole.get(role.id) ?? 0;
+      if (PROTECTED_ROLE_NAMES.has(role.name) || role.base) {
+        skipped.push({ role, reason: 'role protegida/base' });
+      } else if (role.partnerPrepCourse) {
+        skipped.push({ role, reason: 'vinculada a um cursinho' });
+      } else if (role.children && role.children.length > 0) {
+        skipped.push({
+          role,
+          reason: `é roleBase de ${role.children.length} role(s)`,
+        });
+      } else if (users > 0) {
+        skipped.push({ role, reason: `possui ${users} usuário(s)` });
+      } else {
+        eligible.push(role);
+      }
+    }
+
+    console.log(`\nRoles com todas as permissões false: ${candidates.length}`);
+    console.log('\nDetalhamento das candidatas:');
+    for (const role of candidates) {
+      const users = usersByRole.get(role.id) ?? 0;
+      const children = role.children?.length ?? 0;
+      const cursinho = role.partnerPrepCourse ? 'sim' : 'não';
+      console.log(
+        `  - ${role.name} (id=${role.id}) | base=${role.base} | usuarios=${users} | filhas=${children} | cursinho=${cursinho}`,
+      );
+    }
+
+    if (skipped.length > 0) {
+      console.log(`\nIgnoradas por salvaguarda (${skipped.length}):`);
+      for (const { role, reason } of skipped) {
+        console.log(`  - [SKIP] ${role.name} (id=${role.id}) — ${reason}`);
+      }
+    }
+
+    console.log(`\nElegíveis para deleção (${eligible.length}):`);
+    for (const role of eligible) {
+      console.log(`  - ${role.name} (id=${role.id})`);
+    }
+
+    if (eligible.length === 0) {
+      console.log('\nNada a deletar. Encerrando.');
+      return;
+    }
+
+    // Backup antes de qualquer deleção.
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const backupPath = `${__dirname}/roles-backup-${timestamp}.json`;
+    fs.writeFileSync(backupPath, JSON.stringify(eligible, null, 2), 'utf-8');
+    console.log(`\nBackup das roles elegíveis salvo em: ${backupPath}`);
+
+    if (!args.apply) {
+      console.log(
+        '\n[dry-run] Nenhuma role foi deletada. Rode novamente com --apply para deletar.',
+      );
+      return;
+    }
+
+    if (!args.yes) {
+      const ok = await confirm(
+        `\nConfirma a deleção de ${eligible.length} role(s)? [s/N] `,
+      );
+      if (!ok) {
+        console.log('Cancelado. Nenhuma role foi deletada.');
+        return;
+      }
+    }
+
+    const ids = eligible.map((r) => r.id);
+    await ds.transaction(async (manager) => {
+      await manager.getRepository(Role).delete(ids);
+    });
+
+    console.log(`\n${ids.length} role(s) deletada(s) com sucesso.`);
+  } finally {
+    await ds.destroy();
+  }
+}
+
+main().catch((err) => {
+  console.error('Falha ao deletar roles sem permissão:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #499

## O que faz

Adiciona `scripts/delete-roles-without-permissions.ts` (npm run `roles:cleanup:permissions`), espelhando o precedente `scripts/create-admin-user.ts`: script standalone em `ts-node` que reusa o `DataSource`/entities do TypeORM e lê config de `.env` **ou** de variáveis de ambiente (`MY_HOST/MY_PORT/MY_USER/MY_PASSWORD/MY_DB_NAME`) — funciona local, HML e prod.

Deleta roles em que **todas as 28 colunas de permissão são `false`** (equivalentes à `aluno`), que são as roles de teste da fase beta.

## Salvaguardas ⚠️

O dry-run em **homologação** mostrou que o critério puro é destrutivo: a role `aluno` tem todas as permissões false e **1548 usuários**. Por isso o script **nunca** deleta roles que:
- tenham `name` em `('aluno','admin')` ou `base = true`;
- estejam vinculadas a um cursinho (`partnerPrepCourseId`);
- sejam `roleBase` de outra role (`children` não vazio);
- possuam ≥1 usuário (`users.roleId`).

Mais: **dry-run por padrão** (só lista), `--apply` + confirmação `[s/N]` para deletar (`--yes` pula o prompt), **backup `.json`** antes de apagar e **transação** no DELETE.

## Uso

```bash
npm run roles:cleanup:permissions              # dry-run (lista + backup)
npm run roles:cleanup:permissions -- --apply   # lista, confirma e deleta
```

## Validação

- `tsc --noEmit` e `eslint` limpos.
- Dry-run em HML: 6 roles all-false, todas legítimas (aluno, ex-membro de cursinho, 4 base templates com filhas) → **0 elegíveis** (comportamento correto).
- Pendente: rodar dry-run em **produção**, conferir a lista e aplicar (onde o lixo de teste deve estar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)