### PR TITLE
feat(categoria-proxy): Card 03 — 4 endpoints de categoria (proxy + guards)

### DIFF
--- a/src/modules/simulado/categoria/categoria.controller.ts
+++ b/src/modules/simulado/categoria/categoria.controller.ts
@@ -1,21 +1,54 @@
-import { Controller, Get } from '@nestjs/common';
-import { ApiResponse, ApiTags } from '@nestjs/swagger';
-import { CategoriaDTO } from '../dtos/categoria.dto.output';
-import { SimuladoService } from '../simulado.service';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  SetMetadata,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Permissions } from 'src/modules/role/permissions/permissions';
+import { GetAllDtoInput } from 'src/shared/dtos/get-all.dto.input';
+import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
+import { PermissionsGuard } from 'src/shared/guards/permission.guard';
+import { CreateCategoriaDtoInput } from './dtos/create-categoria.dto.input';
+import { CategoriaProxyService } from './categoria.service';
 
 @ApiTags('Simulado - Categoria')
 @Controller('mssimulado/categoria')
 export class CategoriaProxyController {
-  constructor(private readonly simuladoService: SimuladoService) {}
+  constructor(private readonly categoriaService: CategoriaProxyService) {}
 
   @Get()
-  @ApiResponse({
-    status: 200,
-    description: 'busca todas as categorias de simulado',
-    type: CategoriaDTO,
-    isArray: true,
-  })
-  async getCategorias(): Promise<CategoriaDTO[]> {
-    return await this.simuladoService.getCategorias();
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  async getAll(@Query() query: GetAllDtoInput) {
+    return await this.categoriaService.getAll(query.page, query.limit);
+  }
+
+  @Get(':id')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  async getById(@Param('id') id: string) {
+    return await this.categoriaService.getById(id);
+  }
+
+  @Post()
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.alterarPermissao)
+  async create(@Body() dto: CreateCategoriaDtoInput) {
+    return await this.categoriaService.create(dto);
+  }
+
+  @Delete(':id')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.alterarPermissao)
+  async delete(@Param('id') id: string) {
+    return await this.categoriaService.delete(id);
   }
 }

--- a/src/modules/simulado/categoria/categoria.service.spec.ts
+++ b/src/modules/simulado/categoria/categoria.service.spec.ts
@@ -1,0 +1,34 @@
+import { CategoriaProxyService } from './categoria.service';
+
+describe('CategoriaProxyService', () => {
+  let service: CategoriaProxyService;
+  let mockAxios: { get: jest.Mock; post: jest.Mock; delete: jest.Mock };
+
+  beforeEach(() => {
+    mockAxios = { get: jest.fn(), post: jest.fn(), delete: jest.fn() };
+    const mockFactory = { create: jest.fn().mockReturnValue(mockAxios) };
+    const mockEnv = { get: jest.fn().mockReturnValue('http://ms-simulado') };
+    service = new CategoriaProxyService(mockFactory as any, mockEnv as any);
+  });
+
+  it('getAll encaminha page e limit', async () => {
+    await service.getAll(1, 0);
+    expect(mockAxios.get).toHaveBeenCalledWith('v1/categoria?page=1&limit=0');
+  });
+
+  it('getById encaminha o id', async () => {
+    await service.getById('cat-1');
+    expect(mockAxios.get).toHaveBeenCalledWith('v1/categoria/cat-1');
+  });
+
+  it('create faz POST em v1/categoria com o body', async () => {
+    const dto = { nome: 'Custom 10q 30min', duracao: 30, exame: 'e1' } as any;
+    await service.create(dto);
+    expect(mockAxios.post).toHaveBeenCalledWith('v1/categoria', dto);
+  });
+
+  it('delete faz DELETE em v1/categoria/:id', async () => {
+    await service.delete('cat-1');
+    expect(mockAxios.delete).toHaveBeenCalledWith('v1/categoria/cat-1');
+  });
+});

--- a/src/modules/simulado/categoria/categoria.service.ts
+++ b/src/modules/simulado/categoria/categoria.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { EnvService } from 'src/shared/modules/env/env.service';
+import {
+  HttpServiceAxios,
+  HttpServiceAxiosFactory,
+} from 'src/shared/services/axios/http-service-axios.factory';
+import { CreateCategoriaDtoInput } from './dtos/create-categoria.dto.input';
+
+@Injectable()
+export class CategoriaProxyService {
+  private readonly axios: HttpServiceAxios;
+
+  constructor(
+    private readonly httpServiceFactory: HttpServiceAxiosFactory,
+    private readonly envService: EnvService,
+  ) {
+    this.axios = this.httpServiceFactory.create(
+      this.envService.get('SIMULADO_URL'),
+    );
+  }
+
+  async getAll(page: number, limit: number) {
+    return await this.axios.get(`v1/categoria?page=${page}&limit=${limit}`);
+  }
+
+  async getById(id: string) {
+    return await this.axios.get(`v1/categoria/${id}`);
+  }
+
+  async create(dto: CreateCategoriaDtoInput) {
+    return await this.axios.post('v1/categoria', dto);
+  }
+
+  async delete(id: string) {
+    return await this.axios.delete(`v1/categoria/${id}`);
+  }
+}

--- a/src/modules/simulado/categoria/dtos/create-categoria.dto.input.ts
+++ b/src/modules/simulado/categoria/dtos/create-categoria.dto.input.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class CreateCategoriaDtoInput {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  nome?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  prefixo?: string;
+
+  @ApiProperty()
+  @IsNumber()
+  duracao: number;
+
+  @ApiProperty({ required: false, nullable: true })
+  @IsOptional()
+  @IsNumber()
+  quantidadeTotalQuestao?: number | null;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  exame: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  descricao?: string;
+}

--- a/src/modules/simulado/simulado.module.ts
+++ b/src/modules/simulado/simulado.module.ts
@@ -8,6 +8,7 @@ import { AuditLogModule } from '../audit-log/audit-log.module';
 import { CollaboratorFrenteRepository } from '../prepCourse/collaborator/collaborator-frente.repository';
 import { UserModule } from '../user/user.module';
 import { CategoriaProxyController } from './categoria/categoria.controller';
+import { CategoriaProxyService } from './categoria/categoria.service';
 import { ContentProxyController } from './content/content.controller';
 import { ContentProxyService } from './content/content.service';
 import { FrenteProxyController } from './frente/frente.controller';
@@ -55,6 +56,7 @@ import { SubjectProxyService } from './subject/subject.service';
     FrenteProxyService,
     SubjectProxyService,
     ContentProxyService,
+    CategoriaProxyService,
     CollaboratorFrenteRepository,
   ],
   exports: [FrenteProxyService, MateriaProxyService, QuestaoService],


### PR DESCRIPTION
Closes #501

Etapa 3 (CRUD Categoria) — Card 03. Expõe no gateway os 4 endpoints de categoria fazendo proxy pro ms-simulado.

## Summary
- **`CategoriaProxyService`** (novo, padrão `FrenteProxyService`): `getAll(page,limit)`, `getById(id)`, `create(dto)`, `delete(id)` → `v1/categoria*` no ms-simulado.
- **`CategoriaProxyController`** (estendido — já existia com só `@Get()`): agora 4 endpoints:
  - `GET /mssimulado/categoria` (paginado) e `GET /:id` — `@UseGuards(JwtAuthGuard)`.
  - `POST` e `DELETE /:id` — `@UseGuards(JwtAuthGuard, PermissionsGuard)` + `alterarPermissao`.
- **DTO espelho** `CreateCategoriaDtoInput` (nome?, prefixo?, duracao, quantidadeTotalQuestao?, exame, descricao?).
- `CategoriaProxyService` registrado no `SimuladoModule`.

## Decisões / correções vs card
- **Não dupliquei o controller** — o `CategoriaProxyController` já existia (desde a etapa 1, com `@Get() getCategorias()`). Migrei o `@Get()` para paginado + `JwtAuthGuard`. **Seguro**: o client já envia `Bearer token` + `?page&limit` e espera o envelope paginado do ms-simulado.
- **Guard de escrita `JwtAuthGuard, PermissionsGuard`** (não só `PermissionsGuard` como o Frente): o `PermissionsGuard` retorna 403 quando falta token, mas o critério exige **401**. Com `JwtAuthGuard` primeiro: sem token → 401; token sem permissão → 403.
- Erros 409 (delete bloqueado / nome duplicado) e 400 (pattern) do ms-simulado **propagam** via `HttpServiceAxios` (re-throw como `HttpException` com o status upstream).
- **CRUD imutável**: nenhum `PATCH`. Nenhuma rota `/tipos` (confirmado inexistente).

## Test Plan
- [x] 4 unit tests do `CategoriaProxyService` (URLs encaminhadas) — passam; `build` limpo
- [ ] Smoke test homol: POST sem token → 401; POST sem `alterarPermissao` → 403; POST admin → cria; DELETE em uso → 409 `{simuladosUsando}`; GET lista sem soft-deleted

## Follow-up (não-bloqueante)
- `SimuladoService.getCategorias()` fica órfão após a migração do controller — remover em cleanup.
- `custom`/`selecionavel` **propositalmente** fora do DTO (backend força; `whitelist` descarta se enviados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
