### PR TITLE
feat(prova): injeta criadorId/cursinhoId no POST /mssimulado/prova (Card 04)

### DIFF
--- a/src/modules/simulado/dtos/prova-create.dto.request.ts
+++ b/src/modules/simulado/dtos/prova-create.dto.request.ts
@@ -5,6 +5,11 @@ export class CreateProvaDTORequest {
   aplicacao: number = 1;
   ano: number;
   categoria: string;
-  filename: string;
-  gabarito: string;
+  filename?: string;
+  gabarito?: string;
+  nome?: string;
+  nomeSimulado?: string;
+  // Campos internos, injetados pelo api-vcnafacul (não vêm do cliente).
+  criadorId: string;
+  cursinhoId: string | null = null;
 }

--- a/src/modules/simulado/prova/dtos/prova-create.dto.input.ts
+++ b/src/modules/simulado/prova/dtos/prova-create.dto.input.ts
@@ -24,4 +24,14 @@ export class CreateProvaDTOInput {
   @ApiProperty()
   @IsString()
   categoria: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  nome?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  nomeSimulado?: string;
 }

--- a/src/modules/simulado/prova/prova.controller.ts
+++ b/src/modules/simulado/prova/prova.controller.ts
@@ -7,15 +7,18 @@ import {
   Param,
   Patch,
   Post,
+  Req,
   SetMetadata,
-  UploadedFile,
   UploadedFiles,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
 import { Permissions } from 'src/modules/role/permissions/permissions';
+import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
 import { PermissionsGuard } from 'src/shared/guards/permission.guard';
+import { User } from 'src/modules/user/user.entity';
 import { CreateProvaDTOInput } from './dtos/prova-create.dto.input';
 import { ProvaService } from './prova.service';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
@@ -105,7 +108,7 @@ export class ProvaController {
     status: 200,
     description: 'cadastrar provas',
   })
-  @UseGuards(PermissionsGuard)
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
   @SetMetadata(PermissionsGuard.name, Permissions.cadastrarProvas)
   @UseInterceptors(
     FileFieldsInterceptor([
@@ -115,13 +118,18 @@ export class ProvaController {
   )
   public async createProvas(
     @Body() dto: CreateProvaDTOInput,
-    @UploadedFile()
-    files: { file: Express.Multer.File[]; gabarito?: Express.Multer.File[] },
+    @UploadedFiles()
+    files: { file?: Express.Multer.File[]; gabarito?: Express.Multer.File[] },
+    @Req() req: Request,
   ) {
+    // criadorId vem do JWT — nunca do cliente (segurança). cursinhoId é
+    // injetado como null pelo service no fluxo admin atual.
+    const criadorId = (req.user as User).id;
     return await this.provaService.createProva(
       dto,
-      files.file[0],
-      files.gabarito[0],
+      files?.file?.[0],
+      files?.gabarito?.[0],
+      criadorId,
     );
   }
 

--- a/src/modules/simulado/prova/prova.service.spec.ts
+++ b/src/modules/simulado/prova/prova.service.spec.ts
@@ -1,0 +1,76 @@
+import { ProvaService } from './prova.service';
+
+describe('ProvaService.createProva — injeção de criadorId/cursinhoId', () => {
+  let service: ProvaService;
+  let mockAxios: { post: jest.Mock };
+  let mockBlob: { uploadFile: jest.Mock };
+
+  beforeEach(() => {
+    mockAxios = { post: jest.fn().mockResolvedValue({ _id: 'p1' }) };
+    const mockFactory = { create: jest.fn().mockReturnValue(mockAxios) };
+    const mockEnv = { get: jest.fn().mockReturnValue('BUCKET_SIMULADO') };
+    mockBlob = { uploadFile: jest.fn().mockResolvedValue('uploaded-key') };
+    service = new ProvaService(
+      mockFactory as any,
+      mockEnv as any,
+      mockBlob as any,
+      {} as any,
+    );
+  });
+
+  it('injeta criadorId (do param) e cursinhoId null, ignorando o que vier no dto', async () => {
+    const dto = {
+      edicao: 'Regular',
+      ano: '2024',
+      aplicacao: '1',
+      categoria: 'cat1',
+      nome: 'Simuladão',
+      nomeSimulado: 'Simulado Único',
+      criadorId: 'HACKER',
+      cursinhoId: 'HACK-CURSINHO',
+    } as any;
+
+    await service.createProva(dto, { f: 1 }, { g: 1 }, 'real-user');
+
+    expect(mockAxios.post.mock.calls[0][0]).toBe('v1/prova');
+    const sent = mockAxios.post.mock.calls[0][1];
+    expect(sent.criadorId).toBe('real-user');
+    expect(sent.cursinhoId).toBeNull();
+    expect(sent.nome).toBe('Simuladão');
+    expect(sent.nomeSimulado).toBe('Simulado Único');
+  });
+
+  it('funciona sem file/gabarito (prova custom sem PDF)', async () => {
+    const dto = {
+      ano: '2024',
+      aplicacao: '1',
+      categoria: 'cat1',
+      nome: 'Custom',
+      nomeSimulado: 'Sim1',
+    } as any;
+
+    await service.createProva(dto, undefined, undefined, 'u1');
+
+    expect(mockBlob.uploadFile).not.toHaveBeenCalled();
+    const sent = mockAxios.post.mock.calls[0][1];
+    expect(sent.filename).toBeUndefined();
+    expect(sent.gabarito).toBeUndefined();
+    expect(sent.criadorId).toBe('u1');
+    expect(sent.cursinhoId).toBeNull();
+  });
+
+  it('faz upload quando file/gabarito presentes', async () => {
+    const dto = {
+      ano: '2024',
+      aplicacao: '1',
+      categoria: 'cat1',
+    } as any;
+
+    await service.createProva(dto, { name: 'f' }, { name: 'g' }, 'u1');
+
+    expect(mockBlob.uploadFile).toHaveBeenCalledTimes(2);
+    const sent = mockAxios.post.mock.calls[0][1];
+    expect(sent.filename).toBe('uploaded-key');
+    expect(sent.gabarito).toBe('uploaded-key');
+  });
+});

--- a/src/modules/simulado/prova/prova.service.ts
+++ b/src/modules/simulado/prova/prova.service.ts
@@ -28,20 +28,32 @@ export class ProvaService {
     prova: CreateProvaDTOInput,
     file: any,
     gabarito: any,
+    criadorId: string,
   ) {
-    const fileName = await this.blobService.uploadFile(
-      file,
-      this.envService.get('BUCKET_SIMULADO'),
-    );
+    // Arquivos são opcionais (provas custom podem não ter PDF). Só sobe o que veio.
+    let fileName: string | undefined;
+    let gabaritoName: string | undefined;
 
-    const gabaritoName = await this.blobService.uploadFile(
-      gabarito,
-      this.envService.get('BUCKET_SIMULADO'),
-    );
-
-    if (!fileName || !gabaritoName) {
-      throw new HttpException('error to upload file', HttpStatus.BAD_REQUEST);
+    if (file) {
+      fileName = await this.blobService.uploadFile(
+        file,
+        this.envService.get('BUCKET_SIMULADO'),
+      );
+      if (!fileName) {
+        throw new HttpException('error to upload file', HttpStatus.BAD_REQUEST);
+      }
     }
+
+    if (gabarito) {
+      gabaritoName = await this.blobService.uploadFile(
+        gabarito,
+        this.envService.get('BUCKET_SIMULADO'),
+      );
+      if (!gabaritoName) {
+        throw new HttpException('error to upload file', HttpStatus.BAD_REQUEST);
+      }
+    }
+
     const request = new CreateProvaDTORequest();
     request.edicao = prova.edicao;
     request.ano = parseInt(prova.ano as unknown as string);
@@ -49,6 +61,13 @@ export class ProvaService {
     request.categoria = prova.categoria;
     request.filename = fileName;
     request.gabarito = gabaritoName;
+    request.nome = prova.nome;
+    request.nomeSimulado = prova.nomeSimulado;
+    // Injeção pelo backend: criadorId vem do JWT; cursinhoId sempre null no
+    // fluxo admin atual (etapa 6 popula no fluxo cursinho). Ignora o que o
+    // cliente eventualmente enviar.
+    request.criadorId = criadorId;
+    request.cursinhoId = null;
     return await this.axios.post(`v1/prova`, request);
   }
 


### PR DESCRIPTION
## Resumo

Card 04 da **Etapa 4 (Provas Custom)** — a "cola" entre a `CustomProvaFactory` (ms-simulado, PR #160) e o cliente. Garante que o `POST /mssimulado/prova` **injeta** `criadorId` (do JWT) e `cursinhoId: null` antes de proxiar pro ms-simulado, e passa a aceitar provas sem PDF (custom).

## O que mudou
- **Controller** (`createProvas`): guard `@UseGuards(JwtAuthGuard, PermissionsGuard)` + `cadastrarProvas`. `JwtAuthGuard` primeiro para dar **401 sem token** e popular `req.user` (o `PermissionsGuard` não popula). `criadorId = (req.user as User).id` é injetado no service.
- **Service** (`createProva`): recebe `criadorId`, injeta no request enviado ao ms-simulado + `cursinhoId: null`. **Ignora** qualquer `criadorId`/`cursinhoId` que venha no body do cliente.
- **Arquivos opcionais**: `file`/`gabarito` deixam de ser obrigatórios (prova custom pode não ter PDF) — sobe só o que veio.
- **DTOs espelho**: `nome?`/`nomeSimulado?` no input; `nome?`/`nomeSimulado?`/`criadorId`/`cursinhoId` + `filename`/`gabarito` opcionais no request.

## Correções vs. spec do card
- **Guard = `JwtAuthGuard, PermissionsGuard`** (o endpoint usava só `PermissionsGuard`, que dá 403 sem token e não popula `req.user`). Padrão idêntico ao `simulado.controller.answer`.
- **`criadorId` não entra no DTO validado** — é injetado pelo controller a partir do JWT e passado como parâmetro ao service (não confia no cliente).
- **Suporte a PDF opcional** foi necessário aqui (não só no Card 05): o endpoint multipart quebrava em `files.file[0]` quando não havia arquivo.

## Test Plan
- [x] `npm run build` passa
- [x] Unit: `prova.service.spec.ts` — injeção de criadorId/cursinhoId, ignora body malicioso, com/sem arquivos (3/3). Demais unit specs de simulado: 50/50
- [ ] Smoke em homol (depende do ms-simulado #160 deployado):
  - [ ] sem token → 401; token sem `cadastrarProvas` → 403
  - [ ] prova custom (nome + nomeSimulado, sem PDF) → 1 simulado, `criadorId` = user do JWT
  - [ ] prova ENEM Dia 1 (com PDF) → 5 simulados (fluxo antigo intacto)
  - [ ] body com `criadorId`/`cursinhoId` maliciosos → ignorados

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)
