### PR TITLE
[Janela Simulado] Card 03 · api-vcnafacul · proxy PATCH disponibilidade + DTOs

### DIFF
--- a/src/modules/simulado/dtos/simulado.dto.output.ts
+++ b/src/modules/simulado/dtos/simulado.dto.output.ts
@@ -26,4 +26,10 @@ export class SimuladoDTO {
 
   @ApiProperty()
   bloqueado?: boolean;
+
+  @ApiProperty({ required: false, nullable: true })
+  disponivelDe?: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  disponivelAte?: string | null;
 }

--- a/src/modules/simulado/dtos/update-disponibilidade.dto.input.ts
+++ b/src/modules/simulado/dtos/update-disponibilidade.dto.input.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsDate, IsOptional } from 'class-validator';
+
+export class UpdateDisponibilidadeDTO {
+  @ApiProperty({ required: false, nullable: true, type: Date })
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  disponivelDe?: Date | null;
+
+  @ApiProperty({ required: false, nullable: true, type: Date })
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  disponivelAte?: Date | null;
+}

--- a/src/modules/simulado/simulado.controller.ts
+++ b/src/modules/simulado/simulado.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   Req,
@@ -23,6 +24,7 @@ import { AvailableSimuladoDTOoutput } from './dtos/available-simulado.dto.output
 import { ReportDTO } from './dtos/report.dto.input';
 import { SimuladoAnswerDTO } from './dtos/simulado-answer.dto.output';
 import { SimuladoDTO } from './dtos/simulado.dto.output';
+import { UpdateDisponibilidadeDTO } from './dtos/update-disponibilidade.dto.input';
 import { SimuladoService } from './simulado.service';
 
 @ApiTags('Simulado')
@@ -122,6 +124,23 @@ export class SimuladoController {
   @SetMetadata(PermissionsGuard.name, Permissions.cadastrarProvas)
   public async delete(@Param('id') id: string): Promise<void> {
     await this.simuladoService.delete(id);
+  }
+
+  @Patch(':id/disponibilidade')
+  @ApiBearerAuth()
+  @ApiResponse({
+    status: 200,
+    description: 'atualiza a janela de disponibilidade do simulado',
+    type: SimuladoDTO,
+    isArray: false,
+  })
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.cadastrarProvas)
+  public async updateDisponibilidade(
+    @Param('id') id: string,
+    @Body() dto: UpdateDisponibilidadeDTO,
+  ) {
+    return await this.simuladoService.updateDisponibilidade(id, dto);
   }
 
   @Post('report')

--- a/src/modules/simulado/simulado.service.spec.ts
+++ b/src/modules/simulado/simulado.service.spec.ts
@@ -1,0 +1,36 @@
+import { SimuladoService } from './simulado.service';
+
+describe('SimuladoService.updateDisponibilidade (proxy)', () => {
+  let service: SimuladoService;
+  let mockAxios: { patch: jest.Mock };
+
+  beforeEach(() => {
+    mockAxios = {
+      patch: jest.fn().mockResolvedValue({ _id: 's1', disponivelDe: null }),
+    };
+    const mockFactory = { create: jest.fn().mockReturnValue(mockAxios) };
+    const mockEnv = { get: jest.fn().mockReturnValue('http://ms') };
+    service = new SimuladoService(
+      mockFactory as any,
+      mockEnv as any,
+      {} as any, // auditLog
+      {} as any, // cache
+    );
+  });
+
+  it('faz PATCH em v1/simulado/:id/disponibilidade com o dto', async () => {
+    const dto = { disponivelAte: new Date('2026-01-20T00:00:00.000Z') } as any;
+
+    await service.updateDisponibilidade('sim-1', dto);
+
+    expect(mockAxios.patch).toHaveBeenCalledWith(
+      'v1/simulado/sim-1/disponibilidade',
+      dto,
+    );
+  });
+
+  it('retorna o que o ms-simulado devolve', async () => {
+    const result = await service.updateDisponibilidade('sim-1', {} as any);
+    expect(result).toEqual({ _id: 's1', disponivelDe: null });
+  });
+});

--- a/src/modules/simulado/simulado.service.ts
+++ b/src/modules/simulado/simulado.service.ts
@@ -10,6 +10,7 @@ import { AnswerSimulado } from './dtos/answer-simulado.dto.input';
 import { AvailableSimuladoDTOoutput } from './dtos/available-simulado.dto.output';
 import { ReportDTO } from './dtos/report.dto.input';
 import { SimuladoDTO } from './dtos/simulado.dto.output';
+import { UpdateDisponibilidadeDTO } from './dtos/update-disponibilidade.dto.input';
 import { CategoriaDTO } from './dtos/categoria.dto.output';
 import { ReportEntity } from './enum/report.enum';
 import { Status } from './enum/status.enum';
@@ -49,6 +50,13 @@ export class SimuladoService {
 
   public async delete(id: string): Promise<void> {
     await this.axios.delete(`v1/simulado/${id}`);
+  }
+
+  public async updateDisponibilidade(
+    id: string,
+    dto: UpdateDisponibilidadeDTO,
+  ) {
+    return await this.axios.patch(`v1/simulado/${id}/disponibilidade`, dto);
   }
 
   public async answer(dto: AnswerSimulado, userId: string) {

--- a/src/modules/simulado/simulado.service.ts
+++ b/src/modules/simulado/simulado.service.ts
@@ -55,8 +55,11 @@ export class SimuladoService {
   public async updateDisponibilidade(
     id: string,
     dto: UpdateDisponibilidadeDTO,
-  ) {
-    return await this.axios.patch(`v1/simulado/${id}/disponibilidade`, dto);
+  ): Promise<SimuladoDTO> {
+    return await this.axios.patch<SimuladoDTO>(
+      `v1/simulado/${id}/disponibilidade`,
+      dto,
+    );
   }
 
   public async answer(dto: AnswerSimulado, userId: string) {


### PR DESCRIPTION
## [Janela Simulado] Card 03 · api-vcnafacul · Proxy PATCH disponibilidade + DTOs

Etapa 5 (Janela Simulado). Camada de proxy pura no gateway para o endpoint de janela de disponibilidade implementado no ms-simulado (Cards 01+02, PR vcnafacul/ms-simulado#164).

### O que muda
- **`PATCH /mssimulado/simulado/:id/disponibilidade`** — novo endpoint proxy, gated por `JwtAuthGuard` (→ 401 sem token) + `PermissionsGuard` com `cadastrarProvas` (→ 403 sem permissão). Faz `axios.patch` para `v1/simulado/:id/disponibilidade` do ms-simulado.
- **`SimuladoDTO`** (output) ganha `disponivelDe` / `disponivelAte` (`string | null`, ISO), expostos em `GET /mssimulado/simulado/:id` e afins.
- **`UpdateDisponibilidadeDTO`** (input) espelho, com validação `@IsDate` + `@Type(() => Date)` e `@IsOptional` (aceita `null` para limpar).

### Comportamento
- Validação cross-field (`disponivelDe >= disponivelAte` → 400) e o gate 403 vivem no ms-simulado; o axios wrapper propaga status/corpo originais (400/403 do ms surgem intactos, incluindo `{ message, status }` do gate).
- Nenhuma lógica de negócio nova no gateway — proxy puro.

### Testes
- Unit do service (2): PATCH na URL correta com o dto; retorno repassado verbatim.
- **52 testes verdes** no módulo simulado. Build e lint ok.

### Dependência
Requer o deploy do ms-simulado (PR vcnafacul/ms-simulado#164) para funcionar de ponta a ponta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
