### PR TITLE
fix: libera endpoints de aluno gated por permissão de colaborador

### DIFF
--- a/src/modules/essay/essay.controller.ts
+++ b/src/modules/essay/essay.controller.ts
@@ -275,8 +275,9 @@ export class EssayController {
   }
 
   @Get(':id')
-  @UseGuards(JwtAuthGuard, PermissionsGuard)
-  @SetMetadata(PermissionsGuard.name, Permissions.revisarRedacoes)
+  // Aluno visualiza a própria redação (findById filtra por dono);
+  // revisor/admin são autorizados por validateReviewerScope no service
+  @UseGuards(JwtAuthGuard)
   async getEssay(@Param('id') id: string, @Req() req: any) {
     try {
       return await this.essayService.findById(id, req.user.id);

--- a/src/modules/simulado/materia/materia.controller.ts
+++ b/src/modules/simulado/materia/materia.controller.ts
@@ -13,6 +13,7 @@ import {
 import { ApiTags } from '@nestjs/swagger';
 import { Permissions } from 'src/modules/role/permissions/permissions';
 import { GetAllDtoInput } from 'src/shared/dtos/get-all.dto.input';
+import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
 import { PermissionsGuard } from 'src/shared/guards/permission.guard';
 import { MateriaProxyService } from './materia.service';
 
@@ -29,8 +30,8 @@ export class MateriaProxyController {
   }
 
   @Get()
-  @UseGuards(PermissionsGuard)
-  @SetMetadata(PermissionsGuard.name, Permissions.visualizarDemanda)
+  // Listagem de matérias consumida por alunos na página de estudo: exige apenas autenticação
+  @UseGuards(JwtAuthGuard)
   async getAll(@Query() query: GetAllDtoInput) {
     return await this.materiaService.getAll(query.page, query.limit);
   }

--- a/src/modules/simulado/questao/questao.controller.ts
+++ b/src/modules/simulado/questao/questao.controller.ts
@@ -18,6 +18,7 @@ import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { Permissions } from 'src/modules/role/permissions/permissions';
 import { User } from 'src/modules/user/user.entity';
+import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
 import { PermissionsGuard } from 'src/shared/guards/permission.guard';
 import { QuestaoDTOInput } from '../dtos/questao.dto.input';
 import { UpdateImageAlternativaDTOInput } from '../dtos/update-image-alternativa.dto.input';
@@ -245,8 +246,8 @@ export class QuestaoController {
     status: 200,
     description: 'busca imagem de questão',
   })
-  @UseGuards(PermissionsGuard)
-  @SetMetadata(PermissionsGuard.name, Permissions.visualizarQuestao)
+  // Recurso consumido por alunos durante o simulado: exige apenas autenticação
+  @UseGuards(JwtAuthGuard)
   public async getImage(@Param('id') id: string) {
     return await this.questaoService.getImage(id);
   }


### PR DESCRIPTION
## Summary
Três endpoints consumidos por alunos exigiam permissões de **colaborador**, causando **403** para alunos legítimos. Passam a exigir apenas autenticação (`JwtAuthGuard`):

- **`GET /materia`** — listagem de matérias na página de estudo (era `visualizarDemanda`). Dado é catálogo não-sensível; o irmão `GET /materia/grouped-by-area` já é público.
- **`GET /questao/:id/image`** — imagem de questão durante o simulado (era `visualizarQuestao`).
- **`GET /essay/:id`** — aluno visualiza a **própria** redação (era `revisarRedacoes`). Autorização real já vive no service: `findById` filtra por dono e `validateReviewerScope` autoriza revisor/admin. O guard anterior contradizia o próprio handler, que foi escrito para servir dono **e** revisor.

## Why
Padrão recorrente: telas de aluno ("Meus Estudos", simulado, página de estudo) chamavam endpoints protegidos por permissões de área administrativa/correção que alunos nunca possuem.

## Test plan
- [ ] Aluno (sem permissões de colaborador) lista matérias na página de estudo sem 403
- [ ] Aluno carrega imagens de questão durante o simulado
- [ ] Aluno abre o resultado da própria redação (`/dashboard/redacao/:id`)
- [ ] Aluno **não** consegue abrir redação de outro usuário (NotFound via `findById`)
- [ ] Revisor/colaborador do cursinho ainda abre redações dos alunos do seu cursinho (`validateReviewerScope`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)