### PR TITLE
feat(simulado): permissões + endpoints provas cursinho (Etapa 6 Cards 02+03)

### DIFF
--- a/src/db/migrations/1785617601022-add_permissoes_provas_cursinho.ts
+++ b/src/db/migrations/1785617601022-add_permissoes_provas_cursinho.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPermissoesProvasCursinho1785617601022 implements MigrationInterface {
+    name = 'AddPermissoesProvasCursinho1785617601022'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`roles\` ADD \`visualizar_provas_cursinho\` tinyint NOT NULL DEFAULT 0`);
+        await queryRunner.query(`ALTER TABLE \`roles\` ADD \`cadastrar_provas_cursinho\` tinyint NOT NULL DEFAULT 0`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`roles\` DROP COLUMN \`cadastrar_provas_cursinho\``);
+        await queryRunner.query(`ALTER TABLE \`roles\` DROP COLUMN \`visualizar_provas_cursinho\``);
+    }
+
+}

--- a/src/db/seeds/2-role-update-admin.seed.ts
+++ b/src/db/seeds/2-role-update-admin.seed.ts
@@ -46,6 +46,8 @@ export class RoleUpdateAdminSeedService {
         gerenciarTemas: true,
         revisarRedacoes: true,
         revisarTodasRedacoes: true,
+        visualizarProvasCursinho: true,
+        cadastrarProvasCursinho: true,
       });
 
       this.logger.log('Role admin atualizada com sucesso');

--- a/src/modules/prepCourse/collaborator/collaborator.repository.ts
+++ b/src/modules/prepCourse/collaborator/collaborator.repository.ts
@@ -100,6 +100,18 @@ export class CollaboratorRepository extends BaseRepository<Collaborator> {
     });
   }
 
+  async findActiveByUserIdWithPrep(
+    userId: string,
+  ): Promise<Collaborator | null> {
+    return this.repository
+      .createQueryBuilder('entity')
+      .innerJoin('entity.user', 'user')
+      .leftJoinAndSelect('entity.partnerPrepCourse', 'prep')
+      .where('user.id = :userId', { userId })
+      .andWhere('entity.actived = true')
+      .getOne();
+  }
+
   async findActiveByUserIdWithDetails(
     userId: string,
   ): Promise<Collaborator | null> {

--- a/src/modules/role/dto/create-role.dto.ts
+++ b/src/modules/role/dto/create-role.dto.ts
@@ -96,4 +96,12 @@ export class CreateRoleDtoInput {
 
   @IsBoolean()
   editarMateriasFrentes: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  visualizarProvasCursinho?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  cadastrarProvasCursinho?: boolean;
 }

--- a/src/modules/role/permissions/permission-field-map.ts
+++ b/src/modules/role/permissions/permission-field-map.ts
@@ -29,4 +29,6 @@ export const PERMISSION_FIELD_MAP: Record<Permissions, string> = {
   [Permissions.supportAgent]: 'supportAgent',
   [Permissions.partnerPrepSupportAgent]: 'partnerPrepSupportAgent',
   [Permissions.editarMateriasFrentes]: 'editarMateriasFrentes',
+  [Permissions.visualizarProvasCursinho]: 'visualizarProvasCursinho',
+  [Permissions.cadastrarProvasCursinho]: 'cadastrarProvasCursinho',
 };

--- a/src/modules/role/permissions/permission-hierarchy.ts
+++ b/src/modules/role/permissions/permission-hierarchy.ts
@@ -60,6 +60,23 @@ export const PERMISSION_HIERARCHY: PermissionGroup[] = [
     ],
   },
   {
+    key: 'provas_cursinho',
+    label: 'Provas (Cursinho)',
+    permissions: [
+      {
+        key: Permissions.cadastrarProvasCursinho,
+        label: 'Cadastrar provas (cursinho)',
+        type: PermissionType.prepCourse,
+        implies: [Permissions.visualizarProvasCursinho],
+      },
+      {
+        key: Permissions.visualizarProvasCursinho,
+        label: 'Visualizar provas (cursinho)',
+        type: PermissionType.prepCourse,
+      },
+    ],
+  },
+  {
     key: 'demanda',
     label: 'Demanda',
     permissions: [

--- a/src/modules/role/permissions/permission-resolver.spec.ts
+++ b/src/modules/role/permissions/permission-resolver.spec.ts
@@ -1,0 +1,27 @@
+import { Permissions } from './permissions';
+import { PERMISSION_FIELD_MAP } from './permission-field-map';
+import { resolveImpliedPermissions } from './permission-resolver';
+
+describe('resolveImpliedPermissions — provas cursinho', () => {
+  it('cadastrarProvasCursinho implica visualizarProvasCursinho', () => {
+    const resolved = resolveImpliedPermissions({
+      [Permissions.cadastrarProvasCursinho]: true,
+    });
+    expect(resolved[Permissions.visualizarProvasCursinho]).toBe(true);
+  });
+
+  it('visualizarProvasCursinho sozinho não liga cadastrar', () => {
+    const resolved = resolveImpliedPermissions({
+      [Permissions.visualizarProvasCursinho]: true,
+    });
+    expect(resolved[Permissions.cadastrarProvasCursinho]).toBeUndefined();
+  });
+});
+
+describe('PERMISSION_FIELD_MAP — completude', () => {
+  it('todo valor do enum Permissions tem entrada no field map', () => {
+    for (const key of Object.values(Permissions)) {
+      expect(PERMISSION_FIELD_MAP[key]).toBeDefined();
+    }
+  });
+});

--- a/src/modules/role/permissions/permissions.ts
+++ b/src/modules/role/permissions/permissions.ts
@@ -27,4 +27,6 @@ export enum Permissions {
   supportAgent = 'support_agent',
   partnerPrepSupportAgent = 'partner_prep_support_agent',
   editarMateriasFrentes = 'editar_materias_frentes',
+  visualizarProvasCursinho = 'visualizar_provas_cursinho',
+  cadastrarProvasCursinho = 'cadastrar_provas_cursinho',
 }

--- a/src/modules/role/role.entity.ts
+++ b/src/modules/role/role.entity.ts
@@ -117,6 +117,12 @@ export class Role extends BaseEntity {
   @Column({ name: Permissions.editarMateriasFrentes, default: false })
   editarMateriasFrentes: boolean;
 
+  @Column({ name: Permissions.visualizarProvasCursinho, default: false })
+  visualizarProvasCursinho: boolean;
+
+  @Column({ name: Permissions.cadastrarProvasCursinho, default: false })
+  cadastrarProvasCursinho: boolean;
+
   @OneToMany(() => User, (user) => user.role)
   users: User[];
 

--- a/src/modules/role/role.service.spec.ts
+++ b/src/modules/role/role.service.spec.ts
@@ -1,0 +1,49 @@
+import { RoleService } from './role.service';
+import { CreateRoleDtoInput } from './dto/create-role.dto';
+
+function makeService() {
+  const roleRepository = {
+    findOneBy: jest.fn().mockResolvedValue(null),
+    create: jest.fn().mockImplementation(async (r) => r),
+    update: jest.fn().mockImplementation(async (r) => r),
+  };
+  const service = new RoleService(roleRepository as any);
+  return { service, roleRepository };
+}
+
+function baseDto(
+  overrides: Partial<CreateRoleDtoInput> = {},
+): CreateRoleDtoInput {
+  return {
+    name: 'Cursinho X',
+    base: false,
+    ...overrides,
+  } as CreateRoleDtoInput;
+}
+
+describe('RoleService.create — permissões provas cursinho', () => {
+  it('persiste cadastrarProvasCursinho e liga visualizar (implies)', async () => {
+    const { service } = makeService();
+    const role = await service.create(
+      baseDto({ cadastrarProvasCursinho: true }),
+    );
+    expect(role.cadastrarProvasCursinho).toBe(true);
+    expect(role.visualizarProvasCursinho).toBe(true);
+  });
+
+  it('visualizarProvasCursinho sozinho não liga cadastrar', async () => {
+    const { service } = makeService();
+    const role = await service.create(
+      baseDto({ visualizarProvasCursinho: true }),
+    );
+    expect(role.visualizarProvasCursinho).toBe(true);
+    expect(role.cadastrarProvasCursinho).toBe(false);
+  });
+
+  it('sem os campos (undefined) → ambos false', async () => {
+    const { service } = makeService();
+    const role = await service.create(baseDto());
+    expect(role.cadastrarProvasCursinho).toBe(false);
+    expect(role.visualizarProvasCursinho).toBe(false);
+  });
+});

--- a/src/modules/role/role.service.ts
+++ b/src/modules/role/role.service.ts
@@ -109,6 +109,8 @@ export class RoleService extends BaseService<Role> {
       [Permissions.revisarRedacoes]: roleDto.revisarRedacoes,
       [Permissions.partnerPrepSupportAgent]: roleDto.partnerPrepSupportAgent,
       [Permissions.editarMateriasFrentes]: roleDto.editarMateriasFrentes,
+      [Permissions.cadastrarProvasCursinho]: roleDto.cadastrarProvasCursinho,
+      [Permissions.visualizarProvasCursinho]: roleDto.visualizarProvasCursinho,
     });
 
     const role = new Role();
@@ -175,6 +177,8 @@ export class RoleService extends BaseService<Role> {
       [Permissions.supportAgent]: roleDto.supportAgent,
       [Permissions.partnerPrepSupportAgent]: roleDto.partnerPrepSupportAgent,
       [Permissions.editarMateriasFrentes]: roleDto.editarMateriasFrentes,
+      [Permissions.cadastrarProvasCursinho]: roleDto.cadastrarProvasCursinho,
+      [Permissions.visualizarProvasCursinho]: roleDto.visualizarProvasCursinho,
     });
 
     role.name = roleDto.name;

--- a/src/modules/simulado/prova/cursinho/cursinho-prova.controller.spec.ts
+++ b/src/modules/simulado/prova/cursinho/cursinho-prova.controller.spec.ts
@@ -1,0 +1,50 @@
+import { CursinhoProvaController } from './cursinho-prova.controller';
+
+describe('CursinhoProvaController', () => {
+  function make() {
+    const provaService = {
+      createProva: jest.fn().mockResolvedValue({ _id: 'p1' }),
+      getAllByCursinho: jest.fn().mockResolvedValue({ data: [] }),
+    };
+    const resolver = {
+      resolveCursinhoIdByUserId: jest.fn().mockResolvedValue('curs-A'),
+    };
+    const controller = new CursinhoProvaController(
+      provaService as any,
+      resolver as any,
+    );
+    return { controller, provaService, resolver };
+  }
+
+  it('POST injeta criadorId+cursinhoId resolvidos, ignorando o body', async () => {
+    const { controller, provaService, resolver } = make();
+    const req = { user: { id: 'user-1' } } as any;
+    const files = { file: [{ name: 'f' }], gabarito: undefined } as any;
+    const dto = { nome: 'X', criadorId: 'HACK', cursinhoId: 'HACK' } as any;
+
+    await controller.create(dto, files, req);
+
+    expect(resolver.resolveCursinhoIdByUserId).toHaveBeenCalledWith('user-1');
+    expect(provaService.createProva).toHaveBeenCalledWith(
+      dto,
+      { name: 'f' },
+      undefined,
+      'user-1',
+      'curs-A',
+    );
+  });
+
+  it('GET resolve cursinhoId e encaminha page/limit', async () => {
+    const { controller, provaService, resolver } = make();
+    const req = { user: { id: 'user-1' } } as any;
+
+    await controller.getAll('2', '10', req);
+
+    expect(resolver.resolveCursinhoIdByUserId).toHaveBeenCalledWith('user-1');
+    expect(provaService.getAllByCursinho).toHaveBeenCalledWith(
+      'curs-A',
+      '2',
+      '10',
+    );
+  });
+});

--- a/src/modules/simulado/prova/cursinho/cursinho-prova.controller.ts
+++ b/src/modules/simulado/prova/cursinho/cursinho-prova.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Req,
+  SetMetadata,
+  UploadedFiles,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileFieldsInterceptor } from '@nestjs/platform-express';
+import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { Permissions } from 'src/modules/role/permissions/permissions';
+import { User } from 'src/modules/user/user.entity';
+import { JwtAuthGuard } from 'src/shared/guards/jwt-auth.guard';
+import { PermissionsGuard } from 'src/shared/guards/permission.guard';
+import { CreateProvaDTOInput } from '../dtos/prova-create.dto.input';
+import { ProvaService } from '../prova.service';
+import { CursinhoResolverService } from './cursinho-resolver.service';
+
+@ApiTags('Simulado - Prova Cursinho')
+@Controller('mssimulado/cursinho/prova')
+export class CursinhoProvaController {
+  constructor(
+    private readonly provaService: ProvaService,
+    private readonly cursinhoResolver: CursinhoResolverService,
+  ) {}
+
+  @Get()
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'lista provas do cursinho' })
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.visualizarProvasCursinho)
+  public async getAll(
+    @Query('page') page: string,
+    @Query('limit') limit: string,
+    @Req() req: Request,
+  ) {
+    const cursinhoId = await this.cursinhoResolver.resolveCursinhoIdByUserId(
+      (req.user as User).id,
+    );
+    return await this.provaService.getAllByCursinho(cursinhoId, page, limit);
+  }
+
+  @Post()
+  @ApiBearerAuth()
+  @ApiResponse({ status: 200, description: 'cria prova do cursinho' })
+  @UseGuards(JwtAuthGuard, PermissionsGuard)
+  @SetMetadata(PermissionsGuard.name, Permissions.cadastrarProvasCursinho)
+  @UseInterceptors(
+    FileFieldsInterceptor([
+      { name: 'file', maxCount: 1 },
+      { name: 'gabarito', maxCount: 1 },
+    ]),
+  )
+  public async create(
+    @Body() dto: CreateProvaDTOInput,
+    @UploadedFiles()
+    files: { file?: Express.Multer.File[]; gabarito?: Express.Multer.File[] },
+    @Req() req: Request,
+  ) {
+    const userId = (req.user as User).id;
+    const cursinhoId =
+      await this.cursinhoResolver.resolveCursinhoIdByUserId(userId);
+    return await this.provaService.createProva(
+      dto,
+      files?.file?.[0],
+      files?.gabarito?.[0],
+      userId,
+      cursinhoId,
+    );
+  }
+}

--- a/src/modules/simulado/prova/cursinho/cursinho-resolver.service.spec.ts
+++ b/src/modules/simulado/prova/cursinho/cursinho-resolver.service.spec.ts
@@ -1,0 +1,33 @@
+import { ForbiddenException } from '@nestjs/common';
+import { CursinhoResolverService } from './cursinho-resolver.service';
+
+describe('CursinhoResolverService', () => {
+  function make(collab: any) {
+    const collaboratorRepository = {
+      findActiveByUserIdWithPrep: jest.fn().mockResolvedValue(collab),
+    };
+    const service = new CursinhoResolverService(collaboratorRepository as any);
+    return { service, collaboratorRepository };
+  }
+
+  it('retorna o id do partnerPrepCourse do colaborador ativo', async () => {
+    const { service } = make({ partnerPrepCourse: { id: 'curs-1' } });
+    await expect(service.resolveCursinhoIdByUserId('u1')).resolves.toBe(
+      'curs-1',
+    );
+  });
+
+  it('lança Forbidden quando não há colaborador ativo', async () => {
+    const { service } = make(null);
+    await expect(
+      service.resolveCursinhoIdByUserId('u1'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('lança Forbidden quando colaborador sem cursinho vinculado', async () => {
+    const { service } = make({ partnerPrepCourse: null });
+    await expect(
+      service.resolveCursinhoIdByUserId('u1'),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/src/modules/simulado/prova/cursinho/cursinho-resolver.service.ts
+++ b/src/modules/simulado/prova/cursinho/cursinho-resolver.service.ts
@@ -1,0 +1,18 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { CollaboratorRepository } from 'src/modules/prepCourse/collaborator/collaborator.repository';
+
+@Injectable()
+export class CursinhoResolverService {
+  constructor(
+    private readonly collaboratorRepository: CollaboratorRepository,
+  ) {}
+
+  async resolveCursinhoIdByUserId(userId: string): Promise<string> {
+    const collab =
+      await this.collaboratorRepository.findActiveByUserIdWithPrep(userId);
+    if (!collab || !collab.partnerPrepCourse) {
+      throw new ForbiddenException('Usuário não vinculado a nenhum cursinho');
+    }
+    return collab.partnerPrepCourse.id;
+  }
+}

--- a/src/modules/simulado/prova/prova.service.spec.ts
+++ b/src/modules/simulado/prova/prova.service.spec.ts
@@ -74,3 +74,65 @@ describe('ProvaService.createProva — injeção de criadorId/cursinhoId', () =>
     expect(sent.gabarito).toBe('uploaded-key');
   });
 });
+
+describe('ProvaService.getAllByCursinho', () => {
+  function makeService() {
+    const mockAxios = { get: jest.fn().mockResolvedValue({ data: [] }) };
+    const mockFactory = { create: jest.fn().mockReturnValue(mockAxios) };
+    const mockEnv = { get: jest.fn().mockReturnValue('http://ms') };
+    const service = new ProvaService(
+      mockFactory as any,
+      mockEnv as any,
+      {} as any,
+      {} as any,
+    );
+    return { service, mockAxios };
+  }
+
+  it('monta a URL do endpoint cursinho com page/limit', async () => {
+    const { service, mockAxios } = makeService();
+    await service.getAllByCursinho('curs-1', '2', '10');
+    expect(mockAxios.get).toHaveBeenCalledWith(
+      'v1/prova/cursinho/curs-1?page=2&limit=10',
+    );
+  });
+
+  it('sem page/limit → sem query string', async () => {
+    const { service, mockAxios } = makeService();
+    await service.getAllByCursinho('curs-1');
+    expect(mockAxios.get).toHaveBeenCalledWith('v1/prova/cursinho/curs-1');
+  });
+});
+
+describe('ProvaService.createProva — cursinhoId opcional', () => {
+  function makeService() {
+    const mockAxios = { post: jest.fn().mockResolvedValue({ _id: 'p1' }) };
+    const mockFactory = { create: jest.fn().mockReturnValue(mockAxios) };
+    const mockEnv = { get: jest.fn().mockReturnValue('BUCKET_SIMULADO') };
+    const mockBlob = { uploadFile: jest.fn().mockResolvedValue('key') };
+    const service = new ProvaService(
+      mockFactory as any,
+      mockEnv as any,
+      mockBlob as any,
+      {} as any,
+    );
+    return { service, mockAxios };
+  }
+
+  it('injeta o cursinhoId passado (fluxo cursinho)', async () => {
+    const { service, mockAxios } = makeService();
+    const dto = { ano: '2024', aplicacao: '1', categoria: 'c1' } as any;
+    await service.createProva(dto, undefined, undefined, 'user-1', 'curs-9');
+    const sent = mockAxios.post.mock.calls[0][1];
+    expect(sent.cursinhoId).toBe('curs-9');
+    expect(sent.criadorId).toBe('user-1');
+  });
+
+  it('sem o 5º arg → cursinhoId null (admin, retrocompatível)', async () => {
+    const { service, mockAxios } = makeService();
+    const dto = { ano: '2024', aplicacao: '1', categoria: 'c1' } as any;
+    await service.createProva(dto, undefined, undefined, 'user-1');
+    const sent = mockAxios.post.mock.calls[0][1];
+    expect(sent.cursinhoId).toBeNull();
+  });
+});

--- a/src/modules/simulado/prova/prova.service.ts
+++ b/src/modules/simulado/prova/prova.service.ts
@@ -29,6 +29,7 @@ export class ProvaService {
     file: any,
     gabarito: any,
     criadorId: string,
+    cursinhoId: string | null = null,
   ) {
     // Arquivos são opcionais (provas custom podem não ter PDF). Só sobe o que veio.
     let fileName: string | undefined;
@@ -63,11 +64,11 @@ export class ProvaService {
     request.gabarito = gabaritoName;
     request.nome = prova.nome;
     request.nomeSimulado = prova.nomeSimulado;
-    // Injeção pelo backend: criadorId vem do JWT; cursinhoId sempre null no
-    // fluxo admin atual (etapa 6 popula no fluxo cursinho). Ignora o que o
-    // cliente eventualmente enviar.
+    // Injeção pelo backend: criadorId vem do JWT; cursinhoId é null no fluxo
+    // admin e populado no fluxo cursinho (etapa 6). Ignora o que o cliente
+    // eventualmente enviar.
     request.criadorId = criadorId;
-    request.cursinhoId = null;
+    request.cursinhoId = cursinhoId;
     return await this.axios.post(`v1/prova`, request);
   }
 
@@ -77,6 +78,20 @@ export class ProvaService {
 
   public async getProvasAll() {
     return await this.axios.get(`v1/prova`);
+  }
+
+  public async getAllByCursinho(
+    cursinhoId: string,
+    page?: string,
+    limit?: string,
+  ) {
+    const params = new URLSearchParams();
+    if (page) params.set('page', page);
+    if (limit) params.set('limit', limit);
+    const qs = params.toString();
+    return await this.axios.get(
+      `v1/prova/cursinho/${cursinhoId}${qs ? `?${qs}` : ''}`,
+    );
   }
 
   public async getMissingNumbers(id: string) {

--- a/src/modules/simulado/simulado.module.ts
+++ b/src/modules/simulado/simulado.module.ts
@@ -6,6 +6,7 @@ import { HttpServiceAxiosFactory } from 'src/shared/services/axios/http-service-
 import { BlobModule } from 'src/shared/services/blob/blob.module';
 import { AuditLogModule } from '../audit-log/audit-log.module';
 import { CollaboratorFrenteRepository } from '../prepCourse/collaborator/collaborator-frente.repository';
+import { CollaboratorRepository } from '../prepCourse/collaborator/collaborator.repository';
 import { UserModule } from '../user/user.module';
 import { CategoriaProxyController } from './categoria/categoria.controller';
 import { CategoriaProxyService } from './categoria/categoria.service';
@@ -17,6 +18,8 @@ import { MateriaProxyController } from './materia/materia.controller';
 import { MateriaProxyService } from './materia/materia.service';
 import { HistoricoController } from './historico/historico.controller';
 import { HistoricoService } from './historico/historico.service';
+import { CursinhoProvaController } from './prova/cursinho/cursinho-prova.controller';
+import { CursinhoResolverService } from './prova/cursinho/cursinho-resolver.service';
 import { ProvaController } from './prova/prova.controller';
 import { ProvaService } from './prova/prova.service';
 import { QuestaoController } from './questao/questao.controller';
@@ -38,6 +41,7 @@ import { SubjectProxyService } from './subject/subject.service';
   controllers: [
     SimuladoController,
     ProvaController,
+    CursinhoProvaController,
     QuestaoController,
     HistoricoController,
     MateriaProxyController,
@@ -58,6 +62,8 @@ import { SubjectProxyService } from './subject/subject.service';
     ContentProxyService,
     CategoriaProxyService,
     CollaboratorFrenteRepository,
+    CollaboratorRepository,
+    CursinhoResolverService,
   ],
   exports: [FrenteProxyService, MateriaProxyService, QuestaoService],
 })


### PR DESCRIPTION
## Etapa 6 · Cards 02 + 03 — api-vcnafacul

Cadeia encadeada (Card 02 → Card 03). Define as permissões dedicadas do cursinho e expõe os endpoints proxy cursinho-scoped.

### Card 02 — Permissões `visualizar/cadastrarProvasCursinho`
- Enum `Permissions` + `PERMISSION_FIELD_MAP` (Record exaustivo) + novo grupo `provas_cursinho` no `PERMISSION_HIERARCHY` (tipo `prepCourse`, cadastrar ⇒ visualizar).
- 2 colunas em `roles` (entity) + 2 campos **opcionais** (`@IsOptional`) no `CreateRoleDto` (evita quebrar client antigo no deploy api-antes-de-client).
- `RoleService.create` **e** `.update` passam a ler/persistir as 2 permissões (não entram no `BASE_PERMISSIONS` — prepCourse não cascateia).
- Seed admin ganha as 2 = `true`.
- **Migration** `AddPermissoesProvasCursinho` (2 colunas `tinyint NOT NULL DEFAULT 0`).

### Card 03 — `CursinhoResolverService` + `CursinhoProvaController`
- `GET`/`POST /mssimulado/cursinho/prova`, gated por `JwtAuthGuard` (401) + `PermissionsGuard` (403, `visualizar`/`cadastrarProvasCursinho`).
- `CursinhoResolverService` resolve o `cursinhoId` do JWT via `Collaborator` **ativo** (`findActiveByUserIdWithPrep`); sem vínculo/inativo → 403.
- POST injeta `criadorId` + `cursinhoId` **no servidor** (ignora o body); reusa `ProvaService.createProva` (ganhou 5º param opcional `cursinhoId`, retrocompatível com o fluxo admin).
- `getAllByCursinho` proxeia pro ms `GET /v1/prova/cursinho/:cursinhoId`.

### Testes
Build + testes do módulo role e simulado verdes (resolver 403, RoleService persistência+implies, controller segurança/injeção, proxy URL).

⚠️ **Deploy:** rodar a migration em janela; deploy **depois do ms-simulado**, **antes do client**.

Parte da série Provas Cursinho (etapa 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)